### PR TITLE
chore(rrweb): fix the dist files to properly map to typescript checks

### DIFF
--- a/packages/rrdom/src/diff.ts
+++ b/packages/rrdom/src/diff.ts
@@ -1,6 +1,6 @@
 import {
   Mirror as NodeMirror,
-  NodeType as RRNodeType,
+  NodeType as NodeType_2,
   type elementNode,
 } from '@amplitude/rrweb-snapshot';
 import type {
@@ -148,7 +148,7 @@ function diffBeforeUpdatingChildren(
     oldTree = calibratedOldTree;
   }
   switch (newTree.RRNodeType) {
-    case RRNodeType.Document: {
+    case NodeType_2.Document: {
       /**
        * Special cases for updating the document node:
        * Case 1: If the oldTree is the content document of an iframe element and its content (HTML, HEAD, and BODY) is automatically mounted by browsers, we need to remove them to avoid unexpected behaviors. e.g. Selector matches may be case insensitive.
@@ -166,7 +166,7 @@ function diffBeforeUpdatingChildren(
       }
       break;
     }
-    case RRNodeType.Element: {
+    case NodeType_2.Element: {
       const oldElement = oldTree as HTMLElement;
       const newRRElement = newTree as IRRElement;
       switch (newRRElement.tagName) {
@@ -219,12 +219,12 @@ function diffAfterUpdatingChildren(
   replayer: ReplayerHandler,
 ) {
   switch (newTree.RRNodeType) {
-    case RRNodeType.Document: {
+    case NodeType_2.Document: {
       const scrollData = (newTree as RRDocument).scrollData;
       scrollData && replayer.applyScroll(scrollData, true);
       break;
     }
-    case RRNodeType.Element: {
+    case NodeType_2.Element: {
       const oldElement = oldTree as HTMLElement;
       const newRRElement = newTree as RRElement;
       newRRElement.scrollData &&
@@ -312,9 +312,9 @@ function diffAfterUpdatingChildren(
       }
       break;
     }
-    case RRNodeType.Text:
-    case RRNodeType.Comment:
-    case RRNodeType.CDATA: {
+    case NodeType_2.Text:
+    case NodeType_2.Comment:
+    case NodeType_2.CDATA: {
       if (
         oldTree.textContent !==
         (newTree as IRRText | IRRComment | IRRCDATASection).data
@@ -536,17 +536,17 @@ export function createOrGetNode(
   if (nodeId > -1) node = domMirror.getNode(nodeId);
   if (node !== null && sameNodeType(node, rrNode)) return node;
   switch (rrNode.RRNodeType) {
-    case RRNodeType.Document:
+    case NodeType_2.Document:
       node = new Document();
       break;
-    case RRNodeType.DocumentType:
+    case NodeType_2.DocumentType:
       node = document.implementation.createDocumentType(
         (rrNode as IRRDocumentType).name,
         (rrNode as IRRDocumentType).publicId,
         (rrNode as IRRDocumentType).systemId,
       );
       break;
-    case RRNodeType.Element: {
+    case NodeType_2.Element: {
       let tagName = (rrNode as IRRElement).tagName.toLowerCase();
       tagName = SVGTagMap[tagName] || tagName;
       if (sn && 'isSVG' in sn && sn?.isSVG) {
@@ -554,13 +554,13 @@ export function createOrGetNode(
       } else node = document.createElement((rrNode as IRRElement).tagName);
       break;
     }
-    case RRNodeType.Text:
+    case NodeType_2.Text:
       node = document.createTextNode((rrNode as IRRText).data);
       break;
-    case RRNodeType.Comment:
+    case NodeType_2.Comment:
       node = document.createComment((rrNode as IRRComment).data);
       break;
-    case RRNodeType.CDATA:
+    case NodeType_2.CDATA:
       node = document.createCDATASection((rrNode as IRRCDATASection).data);
       break;
   }

--- a/packages/rrdom/src/document.ts
+++ b/packages/rrdom/src/document.ts
@@ -1,4 +1,4 @@
-import { NodeType as RRNodeType } from '@amplitude/rrweb-snapshot';
+import { NodeType as NodeType_2 } from '@amplitude/rrweb-snapshot';
 import { camelize, parseCSSText, toCSSText } from './style';
 export interface IRRNode {
   parentElement: IRRNode | null;
@@ -10,7 +10,7 @@ export interface IRRNode {
   // corresponding nodeType value of standard HTML Node
   readonly nodeType: number;
   readonly nodeName: string; // https://dom.spec.whatwg.org/#dom-node-nodename
-  readonly RRNodeType: RRNodeType;
+  readonly RRNodeType: NodeType_2;
 
   firstChild: IRRNode | null;
 
@@ -140,7 +140,7 @@ export abstract class BaseRRNode implements IRRNode {
   // corresponding nodeType value of standard HTML Node
   public readonly nodeType!: number;
   public readonly nodeName!: string;
-  public readonly RRNodeType!: RRNodeType;
+  public readonly RRNodeType!: NodeType_2;
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
   constructor(..._args: any[]) {
@@ -199,7 +199,7 @@ export class BaseRRDocument extends BaseRRNode implements IRRDocument {
   public readonly nodeType: number = NodeType.DOCUMENT_NODE;
   public readonly nodeName = '#document' as const;
   public readonly compatMode: 'BackCompat' | 'CSS1Compat' = 'CSS1Compat';
-  public readonly RRNodeType = RRNodeType.Document;
+  public readonly RRNodeType = NodeType_2.Document;
   public textContent: string | null = null;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -212,7 +212,7 @@ export class BaseRRDocument extends BaseRRNode implements IRRDocument {
     return (
       (this.childNodes.find(
         (node) =>
-          node.RRNodeType === RRNodeType.Element &&
+          node.RRNodeType === NodeType_2.Element &&
           (node as IRRElement).tagName === 'HTML',
       ) as IRRElement) || null
     );
@@ -222,7 +222,7 @@ export class BaseRRDocument extends BaseRRNode implements IRRDocument {
     return (
       (this.documentElement?.childNodes.find(
         (node) =>
-          node.RRNodeType === RRNodeType.Element &&
+          node.RRNodeType === NodeType_2.Element &&
           (node as IRRElement).tagName === 'BODY',
       ) as IRRElement) || null
     );
@@ -232,7 +232,7 @@ export class BaseRRDocument extends BaseRRNode implements IRRDocument {
     return (
       (this.documentElement?.childNodes.find(
         (node) =>
-          node.RRNodeType === RRNodeType.Element &&
+          node.RRNodeType === NodeType_2.Element &&
           (node as IRRElement).tagName === 'HEAD',
       ) as IRRElement) || null
     );
@@ -249,13 +249,13 @@ export class BaseRRDocument extends BaseRRNode implements IRRDocument {
   public appendChild(newChild: IRRNode): IRRNode {
     const nodeType = newChild.RRNodeType;
     if (
-      nodeType === RRNodeType.Element ||
-      nodeType === RRNodeType.DocumentType
+      nodeType === NodeType_2.Element ||
+      nodeType === NodeType_2.DocumentType
     ) {
       if (this.childNodes.some((s) => s.RRNodeType === nodeType)) {
         throw new Error(
           `RRDomException: Failed to execute 'appendChild' on 'RRNode': Only one ${
-            nodeType === RRNodeType.Element ? 'RRElement' : 'RRDoctype'
+            nodeType === NodeType_2.Element ? 'RRElement' : 'RRDoctype'
           } on RRDocument allowed.`,
         );
       }
@@ -269,13 +269,13 @@ export class BaseRRDocument extends BaseRRNode implements IRRDocument {
   public insertBefore(newChild: IRRNode, refChild: IRRNode | null): IRRNode {
     const nodeType = newChild.RRNodeType;
     if (
-      nodeType === RRNodeType.Element ||
-      nodeType === RRNodeType.DocumentType
+      nodeType === NodeType_2.Element ||
+      nodeType === NodeType_2.DocumentType
     ) {
       if (this.childNodes.some((s) => s.RRNodeType === nodeType)) {
         throw new Error(
           `RRDomException: Failed to execute 'insertBefore' on 'RRNode': Only one ${
-            nodeType === RRNodeType.Element ? 'RRElement' : 'RRDoctype'
+            nodeType === NodeType_2.Element ? 'RRElement' : 'RRDoctype'
           } on RRDocument allowed.`,
         );
       }
@@ -380,7 +380,7 @@ export class BaseRRDocument extends BaseRRNode implements IRRDocument {
 
 export class BaseRRDocumentType extends BaseRRNode implements IRRDocumentType {
   public readonly nodeType: number = NodeType.DOCUMENT_TYPE_NODE;
-  public readonly RRNodeType = RRNodeType.DocumentType;
+  public readonly RRNodeType = NodeType_2.DocumentType;
   declare readonly nodeName: string;
   public readonly name: string;
   public readonly publicId: string;
@@ -402,7 +402,7 @@ export class BaseRRDocumentType extends BaseRRNode implements IRRDocumentType {
 
 export class BaseRRElement extends BaseRRNode implements IRRElement {
   public readonly nodeType: number = NodeType.ELEMENT_NODE;
-  public readonly RRNodeType = RRNodeType.Element;
+  public readonly RRNodeType = NodeType_2.Element;
   declare readonly nodeName: string;
   public tagName: string;
   public attributes: Record<string, string> = {};
@@ -575,7 +575,7 @@ export class BaseRRDialogElement extends BaseRRElement {
 export class BaseRRText extends BaseRRNode implements IRRText {
   public readonly nodeType: number = NodeType.TEXT_NODE;
   public readonly nodeName = '#text' as const;
-  public readonly RRNodeType = RRNodeType.Text;
+  public readonly RRNodeType = NodeType_2.Text;
   public data: string;
 
   constructor(data: string) {
@@ -599,7 +599,7 @@ export class BaseRRText extends BaseRRNode implements IRRText {
 export class BaseRRComment extends BaseRRNode implements IRRComment {
   public readonly nodeType: number = NodeType.COMMENT_NODE;
   public readonly nodeName = '#comment' as const;
-  public readonly RRNodeType = RRNodeType.Comment;
+  public readonly RRNodeType = NodeType_2.Comment;
   public data: string;
 
   constructor(data: string) {
@@ -623,7 +623,7 @@ export class BaseRRComment extends BaseRRNode implements IRRComment {
 export class BaseRRCDATASection extends BaseRRNode implements IRRCDATASection {
   public readonly nodeName = '#cdata-section' as const;
   public readonly nodeType: number = NodeType.CDATA_SECTION_NODE;
-  public readonly RRNodeType = RRNodeType.CDATA;
+  public readonly RRNodeType = NodeType_2.CDATA;
   public data: string;
 
   constructor(data: string) {

--- a/packages/rrdom/src/index.ts
+++ b/packages/rrdom/src/index.ts
@@ -4,7 +4,7 @@ import type {
   serializedNodeWithId,
 } from '@amplitude/rrweb-snapshot';
 import {
-  NodeType as RRNodeType,
+  NodeType as NodeType_2,
   createMirror as createNodeMirror,
 } from '@amplitude/rrweb-snapshot';
 import type {
@@ -415,13 +415,13 @@ export class Mirror implements IMirror<RRNode> {
  */
 export function getDefaultSN(node: IRRNode, id: number): serializedNodeWithId {
   switch (node.RRNodeType) {
-    case RRNodeType.Document:
+    case NodeType_2.Document:
       return {
         id,
         type: node.RRNodeType,
         childNodes: [],
       };
-    case RRNodeType.DocumentType: {
+    case NodeType_2.DocumentType: {
       const doctype = node as IRRDocumentType;
       return {
         id,
@@ -431,7 +431,7 @@ export function getDefaultSN(node: IRRNode, id: number): serializedNodeWithId {
         systemId: doctype.systemId,
       };
     }
-    case RRNodeType.Element:
+    case NodeType_2.Element:
       return {
         id,
         type: node.RRNodeType,
@@ -439,19 +439,19 @@ export function getDefaultSN(node: IRRNode, id: number): serializedNodeWithId {
         attributes: {},
         childNodes: [],
       };
-    case RRNodeType.Text:
+    case NodeType_2.Text:
       return {
         id,
         type: node.RRNodeType,
         textContent: (node as IRRText).textContent || '',
       };
-    case RRNodeType.Comment:
+    case NodeType_2.Comment:
       return {
         id,
         type: node.RRNodeType,
         textContent: (node as IRRComment).textContent || '',
       };
-    case RRNodeType.CDATA:
+    case NodeType_2.CDATA:
       return {
         id,
         type: node.RRNodeType,
@@ -471,7 +471,7 @@ export function printRRDom(rootNode: IRRNode, mirror: IMirror<IRRNode>) {
 }
 function walk(node: IRRNode, mirror: IMirror<IRRNode>, blankSpace: string) {
   let printText = `${blankSpace}${mirror.getId(node)} ${node.toString()}\n`;
-  if (node.RRNodeType === RRNodeType.Element) {
+  if (node.RRNodeType === NodeType_2.Element) {
     const element = node as IRRElement;
     if (element.shadowRoot)
       printText += walk(element.shadowRoot, mirror, blankSpace + '  ');

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -62,7 +62,7 @@ try {
 }
 
 const mirror = createMirror();
-function record<T = eventWithTime>(
+export function record<T = eventWithTime>(
   options: recordOptions<T> = {},
 ): listenerHandler | undefined {
   const {


### PR DESCRIPTION
The generated typescript files have conflicting namespaces, so I am using the generated names inside the .ts files. We can wait for the upstream changes to come in to sync with their naming. 