### PR TITLE
fix: ensure pause method is called only if it exists

### DIFF
--- a/.changeset/cuddly-ears-joke.md
+++ b/.changeset/cuddly-ears-joke.md
@@ -1,0 +1,5 @@
+---
+"@amplitude/rrweb": patch
+---
+
+fix: ensure pause method is called only if it exists

--- a/packages/rrweb/src/replay/media/index.ts
+++ b/packages/rrweb/src/replay/media/index.ts
@@ -57,7 +57,7 @@ export class MediaManager {
     this.mediaMap.forEach((_mediaState, target) => {
       this.syncTargetWithState(target);
       if (options.pause) {
-        target.pause();
+        target.pause && target.pause();
       }
     });
   }


### PR DESCRIPTION
**Context**

When `this.mediaMap.set()` is [called](https://github.com/amplitude/rrweb/blob/897a93893b40598eb33d9de22cdeaa9194186305/packages/rrweb/src/replay/media/index.ts#L279), it looks like the `target` parameter is a `Node` type [which has been cast to `HTMLMediaElement`](https://github.com/amplitude/rrweb/blob/897a93893b40598eb33d9de22cdeaa9194186305/packages/rrweb/src/replay/media/index.ts#L213).  

`Node` does not have a `pause()` method.  Add additional handling in case the `pause()` function is unavailable.