### PR TITLE
Enable adding a background color on blocked elements

### DIFF
--- a/.changeset/famous-walls-sparkle.md
+++ b/.changeset/famous-walls-sparkle.md
@@ -1,0 +1,6 @@
+---
+"@amplitude/rrweb-snapshot": patch
+"@amplitude/rrweb": patch
+---
+
+Enable adding a background color on blocked elements

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -335,6 +335,11 @@ function buildNode(
           (node as HTMLElement).style.setProperty('width', value.toString());
         } else if (name === 'rr_height') {
           (node as HTMLElement).style.setProperty('height', value.toString());
+        } else if (name === 'rr_background_color') {
+          (node as HTMLElement).style.setProperty(
+            'background-color',
+            value.toString(),
+          );
         } else if (
           name === 'rr_mediaCurrentTime' &&
           typeof value === 'number'

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -1081,6 +1081,7 @@ export function serializeNodeWithId(
       stylesheetLoadTimeout,
       keepIframeSrcFn,
       cssCaptured: false,
+      applyBackgroundColorToBlockedElements,
     };
 
     if (

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -33,6 +33,8 @@ import {
 } from './utils';
 import dom from '@amplitude/rrweb-utils';
 
+const _DEFAULT_BLOCKED_ELEMENT_BACKGROUND_COLOR = 'lightgrey';
+
 let _id = 1;
 const tagNameRegex = new RegExp('[^a-z0-9-_:]');
 
@@ -576,6 +578,7 @@ function serializeElementNode(
     keepIframeSrcFn,
     newlyAddedElement = false,
     rootId,
+    applyBackgroundColorToBlockedElements = false,
   } = options;
   const needBlock = _isBlockedElement(n, blockClass, blockSelector);
   const tagName = getValidTagName(n);
@@ -768,6 +771,9 @@ function serializeElementNode(
       class: attributes.class,
       rr_width: `${width}px`,
       rr_height: `${height}px`,
+      ...(applyBackgroundColorToBlockedElements
+        ? { rr_background_color: _DEFAULT_BLOCKED_ELEMENT_BACKGROUND_COLOR }
+        : {}),
     };
   }
   // iframe

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -407,6 +407,7 @@ function serializeNode(
      */
     newlyAddedElement?: boolean;
     cssCaptured?: boolean;
+    applyBackgroundColorToBlockedElements?: boolean;
   },
 ): serializedNode | false {
   const {
@@ -425,6 +426,7 @@ function serializeNode(
     keepIframeSrcFn,
     newlyAddedElement = false,
     cssCaptured = false,
+    applyBackgroundColorToBlockedElements = false,
   } = options;
   // Only record root id when document object is not the base document
   const rootId = getRootId(doc, mirror);
@@ -464,6 +466,7 @@ function serializeNode(
         keepIframeSrcFn,
         newlyAddedElement,
         rootId,
+        applyBackgroundColorToBlockedElements,
       });
     case n.TEXT_NODE:
       return serializeTextNode(n as Text, {
@@ -557,6 +560,7 @@ function serializeElementNode(
      */
     newlyAddedElement?: boolean;
     rootId: number | undefined;
+    applyBackgroundColorToBlockedElements?: boolean;
   },
 ): serializedNode | false {
   const {
@@ -931,6 +935,7 @@ export function serializeNodeWithId(
     ) => unknown;
     stylesheetLoadTimeout?: number;
     cssCaptured?: boolean;
+    applyBackgroundColorToBlockedElements?: boolean;
   },
 ): serializedNodeWithId | null {
   const {
@@ -957,6 +962,7 @@ export function serializeNodeWithId(
     keepIframeSrcFn = () => false,
     newlyAddedElement = false,
     cssCaptured = false,
+    applyBackgroundColorToBlockedElements = false,
   } = options;
   let { needsMask } = options;
   let { preserveWhiteSpace = true } = options;
@@ -988,6 +994,7 @@ export function serializeNodeWithId(
     keepIframeSrcFn,
     newlyAddedElement,
     cssCaptured,
+    applyBackgroundColorToBlockedElements,
   });
   if (!_serializedNode) {
     // TODO: dev only
@@ -1241,6 +1248,7 @@ function snapshot(
     ) => unknown;
     stylesheetLoadTimeout?: number;
     keepIframeSrcFn?: KeepIframeSrcFn;
+    applyBackgroundColorToBlockedElements?: boolean;
   },
 ): serializedNodeWithId | null {
   const {
@@ -1264,6 +1272,7 @@ function snapshot(
     onStylesheetLoad,
     stylesheetLoadTimeout,
     keepIframeSrcFn = () => false,
+    applyBackgroundColorToBlockedElements = false,
   } = options || {};
   const maskInputOptions: MaskInputOptions =
     maskAllInputs === true
@@ -1332,6 +1341,7 @@ function snapshot(
     stylesheetLoadTimeout,
     keepIframeSrcFn,
     newlyAddedElement: false,
+    applyBackgroundColorToBlockedElements,
   });
 }
 

--- a/packages/rrweb-snapshot/test/rebuild.test.ts
+++ b/packages/rrweb-snapshot/test/rebuild.test.ts
@@ -72,7 +72,7 @@ describe('rebuild', function () {
     });
   });
 
-  describe('rr_width/rr_height', function () {
+  describe('rr_width/rr_height/rr_background_color', function () {
     it('rebuild blocked element with correct dimensions', function () {
       const node = buildNodeWithSN(
         {
@@ -95,6 +95,27 @@ describe('rebuild', function () {
       ) as HTMLDivElement;
       expect(node.style.width).toBe('50px');
       expect(node.style.height).toBe('50px');
+    });
+
+    it('rebuild blocked elements with correct background color', function () {
+      const node = buildNodeWithSN(
+        {
+          id: 1,
+          tagName: 'div',
+          type: NodeType.Element,
+          attributes: {
+            rr_background_color: 'lightgrey',
+          },
+          childNodes: [],
+        },
+        {
+          doc: document,
+          mirror,
+          hackCss: false,
+          cache,
+        },
+      ) as HTMLDivElement;
+      expect(node.style.backgroundColor).toBe('lightgrey');
     });
   });
 

--- a/packages/rrweb-snapshot/test/snapshot.test.ts
+++ b/packages/rrweb-snapshot/test/snapshot.test.ts
@@ -156,27 +156,81 @@ describe('isBlockedElement()', () => {
     ).toEqual(true);
   });
 
-  it('adds background color attribute when element is blocked and applyBackgroundColorToBlockedElements is true', () => {
-    const applyBackgroundColorToBlockedElements = true;
-    const html = '<div class="rr-block">Blocked content</div>';
-    const el = render(html);
-    const serialized = serializeNode(el, applyBackgroundColorToBlockedElements);
-    expect(subject(html)).toEqual(true);
-    expect(serialized).toMatchObject({
-      attributes: {
-        rr_background_color: 'lightgrey',
-      },
-    });
-  });
+  it.each([
+    {
+      description: 'adds',
+      applyBackgroundColorToBlockedElements: true,
+      expectedAttributes: { rr_background_color: 'lightgrey' },
+    },
+    {
+      description: 'does not add',
+      applyBackgroundColorToBlockedElements: false,
+      expectedAttributes: {},
+    },
+  ])(
+    '$description background color attribute when element is blocked and applyBackgroundColorToBlockedElements is $applyBackground',
+    ({ applyBackgroundColorToBlockedElements, expectedAttributes }) => {
+      // Arrange
+      // NOTE: `blockblock` is the blockClass configured in the serializeNode helper above
+      const html = '<div class="blockblock">Blocked content</div>';
+      const el = render(html);
 
-  it('does not add background color attribute when element is blocked and applyBackgroundColorToBlockedElements is false', () => {
-    const applyBackgroundColorToBlockedElements = false;
-    const html = '<div class="rr-block">Blocked content</div>';
-    const el = render(html);
-    const serialized = serializeNode(el, applyBackgroundColorToBlockedElements);
-    expect(subject(html)).toEqual(true);
-    expect(serialized.attributes).not.toHaveProperty('rr_background_color');
-  });
+      // Act
+      const serialized = serializeNode(
+        el,
+        applyBackgroundColorToBlockedElements,
+      );
+
+      // Assert
+      expect(serialized.attributes).toEqual({
+        rr_width: '0px',
+        rr_height: '0px',
+        class: 'blockblock',
+        ...expectedAttributes,
+      });
+    },
+  );
+
+  it.each([
+    {
+      description: 'should add',
+      applyBackgroundColorToBlockedElements: true,
+      expectedAttributes: { rr_background_color: 'lightgrey' },
+    },
+    {
+      description: 'should not add',
+      applyBackgroundColorToBlockedElements: false,
+      expectedAttributes: {},
+    },
+  ])(
+    '$description background color to blocked nested elements when applyBackgroundColorToBlockedElements is $applyBackground',
+    ({ applyBackgroundColorToBlockedElements, expectedAttributes }) => {
+      // Arrange
+      // NOTE: `blockblock` is the blockClass configured in the serializeNode helper above
+      const html =
+        '<div>Allowed Content with <span class="blockblock">Blocked content</span></div>';
+      const el = render(html);
+
+      // Act
+      const serialized = serializeNode(
+        el,
+        applyBackgroundColorToBlockedElements,
+      );
+
+      // Find the span child node
+      const spanNode = serialized.childNodes.find(
+        (node) => node.type === 2 && node.tagName === 'span',
+      ) as elementNode;
+
+      // Assert
+      expect(spanNode.attributes).toEqual({
+        class: 'blockblock',
+        rr_width: '0px',
+        rr_height: '0px',
+        ...expectedAttributes,
+      });
+    },
+  );
 });
 
 describe('style elements', () => {

--- a/packages/rrweb-snapshot/test/snapshot.test.ts
+++ b/packages/rrweb-snapshot/test/snapshot.test.ts
@@ -11,7 +11,10 @@ import snapshot, {
 import { elementNode, serializedNodeWithId } from '../src/types';
 import { Mirror, absolutifyURLs } from '../src/utils';
 
-const serializeNode = (node: Node): serializedNodeWithId | null => {
+const serializeNode = (
+  node: Node,
+  applyBackgroundColorToBlockedElements: boolean = false,
+): serializedNodeWithId | null => {
   return serializeNodeWithId(node, {
     doc: document,
     mirror: new Mirror(),
@@ -24,6 +27,7 @@ const serializeNode = (node: Node): serializedNodeWithId | null => {
     maskTextFn: undefined,
     maskInputFn: undefined,
     slimDOMOptions: {},
+    applyBackgroundColorToBlockedElements,
   });
 };
 
@@ -150,6 +154,28 @@ describe('isBlockedElement()', () => {
     expect(
       subject('<div data-rr-block />', { blockSelector: '[data-rr-block]' }),
     ).toEqual(true);
+  });
+
+  it('adds background color attribute when element is blocked and applyBackgroundColorToBlockedElements is true', () => {
+    const applyBackgroundColorToBlockedElements = true;
+    const html = '<div class="rr-block">Blocked content</div>';
+    const el = render(html);
+    const serialized = serializeNode(el, applyBackgroundColorToBlockedElements);
+    expect(subject(html)).toEqual(true);
+    expect(serialized).toMatchObject({
+      attributes: {
+        rr_background_color: 'lightgrey',
+      },
+    });
+  });
+
+  it('does not add background color attribute when element is blocked and applyBackgroundColorToBlockedElements is false', () => {
+    const applyBackgroundColorToBlockedElements = false;
+    const html = '<div class="rr-block">Blocked content</div>';
+    const el = render(html);
+    const serialized = serializeNode(el, applyBackgroundColorToBlockedElements);
+    expect(subject(html)).toEqual(true);
+    expect(serialized.attributes).not.toHaveProperty('rr_background_color');
   });
 });
 

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -99,6 +99,7 @@ export function record<T = eventWithTime>(
     keepIframeSrcFn = () => false,
     ignoreCSSAttributes = new Set([]),
     errorHandler,
+    applyBackgroundColorToBlockedElements = false,
   } = options;
 
   registerErrorHandler(errorHandler);
@@ -389,6 +390,7 @@ export function record<T = eventWithTime>(
       dataURLOptions,
       recordCanvas,
       inlineImages,
+      applyBackgroundColorToBlockedElements,
       onSerialize: (n) => {
         if (isSerializedIframe(n, mirror)) {
           iframeManager.addIframe(n as HTMLIFrameElement);

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -74,6 +74,7 @@ export type recordOptions<T> = {
   mousemoveWait?: number;
   keepIframeSrcFn?: KeepIframeSrcFn;
   errorHandler?: ErrorHandler;
+  applyBackgroundColorToBlockedElements?: boolean;
 };
 
 export type observerParam = {


### PR DESCRIPTION
## Summary 

Support ability to add a background color on blocked elements.  At present, the blocked elements will retain the following attributes when the snapshot is created: height, width, and classes.  

This results in a blank element in the replay.  In other words, the space the element would occupy is still present, but it is blank.  

This change supports the ability to add a background color to these blocked elements to indicate that there _was_ an element that was then redacted.

## Validation:
- Unit tests
- Installed this package in a test application and confirmed that it added a background to the blocked element.