### PR TITLE
fix: skip invalid custom element creation

### DIFF
--- a/.changeset/eighty-dragons-smoke.md
+++ b/.changeset/eighty-dragons-smoke.md
@@ -1,0 +1,5 @@
+---
+"@amplitude/rrweb-snapshot": patch
+---
+
+fix: skip invalid custom element creation

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -56,7 +56,6 @@ const tagMap: tagMap = {
 function getTagName(n: elementNode): string {
   let tagName = tagMap[n.tagName] ? tagMap[n.tagName] : n.tagName;
   if (tagName === 'link' && n.attributes._cssText) {
-    console.log("link is not a valid custom element name, build as style instead");
     tagName = 'style';
   }
 

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -10,6 +10,9 @@ import { type tagMap, type BuildCache } from './types';
 import { isElement, Mirror, isNodeMetaEqual } from './utils';
 import postcss from 'postcss';
 
+// Tag names that should not be defined as custom elements
+const customElementExclusions = ['webview'];
+
 const tagMap: tagMap = {
   script: 'noscript',
   // camel case svg element tag names
@@ -53,8 +56,10 @@ const tagMap: tagMap = {
 function getTagName(n: elementNode): string {
   let tagName = tagMap[n.tagName] ? tagMap[n.tagName] : n.tagName;
   if (tagName === 'link' && n.attributes._cssText) {
+    console.log("link is not a valid custom element name, build as style instead");
     tagName = 'style';
   }
+
   return tagName;
 }
 
@@ -185,7 +190,9 @@ function buildNode(
           // If the browser supports custom elements
           doc.defaultView?.customElements &&
           // If the custom element hasn't been defined yet
-          !doc.defaultView.customElements.get(n.tagName)
+          !doc.defaultView.customElements.get(n.tagName) &&
+          // If the tag is not in the exclusion list
+          !customElementExclusions.includes(n.tagName)
         )
           doc.defaultView.customElements.define(
             n.tagName,

--- a/packages/rrweb-snapshot/test/rebuild.test.ts
+++ b/packages/rrweb-snapshot/test/rebuild.test.ts
@@ -153,7 +153,7 @@ describe('rebuild', function () {
   describe('customElementExclusions', function () {
     it('should not define custom elements for excluded tag names', function () {
       const spy = vi.spyOn(customElements, 'define');
-      
+
       const node = buildNodeWithSN(
         {
           id: 1,
@@ -170,17 +170,17 @@ describe('rebuild', function () {
           cache,
         },
       ) as HTMLElement;
-      
+
       expect(node.tagName.toLowerCase()).toBe('webview');
       expect(spy).not.toHaveBeenCalledWith('webview', expect.anything());
-      
+
       spy.mockRestore();
     });
 
     it('should still define custom elements for non-excluded tag names', function () {
       const customTagName = 'my-custom-element';
       const spy = vi.spyOn(customElements, 'define');
-      
+
       const node = buildNodeWithSN(
         {
           id: 1,
@@ -197,10 +197,10 @@ describe('rebuild', function () {
           cache,
         },
       ) as HTMLElement;
-      
+
       expect(node.tagName.toLowerCase()).toBe(customTagName);
       expect(spy).toHaveBeenCalledWith(customTagName, expect.anything());
-      
+
       spy.mockRestore();
     });
   });

--- a/packages/rrweb-snapshot/test/rebuild.test.ts
+++ b/packages/rrweb-snapshot/test/rebuild.test.ts
@@ -150,6 +150,61 @@ describe('rebuild', function () {
     });
   });
 
+  describe('customElementExclusions', function () {
+    it('should not define custom elements for excluded tag names', function () {
+      const spy = vi.spyOn(customElements, 'define');
+      
+      const node = buildNodeWithSN(
+        {
+          id: 1,
+          tagName: 'webview',
+          type: NodeType.Element,
+          isCustom: true,
+          attributes: {},
+          childNodes: [],
+        },
+        {
+          doc: document,
+          mirror,
+          hackCss: false,
+          cache,
+        },
+      ) as HTMLElement;
+      
+      expect(node.tagName.toLowerCase()).toBe('webview');
+      expect(spy).not.toHaveBeenCalledWith('webview', expect.anything());
+      
+      spy.mockRestore();
+    });
+
+    it('should still define custom elements for non-excluded tag names', function () {
+      const customTagName = 'my-custom-element';
+      const spy = vi.spyOn(customElements, 'define');
+      
+      const node = buildNodeWithSN(
+        {
+          id: 1,
+          tagName: customTagName,
+          type: NodeType.Element,
+          isCustom: true,
+          attributes: {},
+          childNodes: [],
+        },
+        {
+          doc: document,
+          mirror,
+          hackCss: false,
+          cache,
+        },
+      ) as HTMLElement;
+      
+      expect(node.tagName.toLowerCase()).toBe(customTagName);
+      expect(spy).toHaveBeenCalledWith(customTagName, expect.anything());
+      
+      spy.mockRestore();
+    });
+  });
+
   describe('add hover class to hover selector related rules', function () {
     it('will do nothing to css text without :hover', () => {
       const cssText = 'body { color: white }';


### PR DESCRIPTION
On electron applications, there is a custom element `webview`. This breaks the rebuild process since custom elements on browsers require hyphens in the `tagName`. Adding a process for us to skip over the custom element definition for certain elements. 

https://amplitude.atlassian.net/browse/SR-1885?focusedCommentId=357042