### PR TITLE
chore: stub out new workflow

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -1,0 +1,16 @@
+name: Upstream Sync Monitor
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Skip push and PR creation (validate pipeline only)'
+        type: boolean
+        default: false
+
+jobs:
+  sync:
+    name: Sync upstream rrweb commits
+    runs-on: ubuntu-22.04
+    steps:
+      - run: echo "Upstream sync stub. Full implementation coming in feat/upstream-sync."


### PR DESCRIPTION
Stubbing our a workflow file, so that we can test changes locally. 