### PR TITLE
fix(snapshot): serialize adoptedStyleSheets inline in full snapshot

### DIFF
--- a/.changeset/inline-adopted-stylesheets.md
+++ b/.changeset/inline-adopted-stylesheets.md
@@ -1,0 +1,7 @@
+---
+"@amplitude/rrweb": minor
+"@amplitude/rrweb-snapshot": patch
+"@amplitude/rrweb-types": patch
+---
+
+Fix adoptedStyleSheets CSS not applied on replay when incremental AdoptedStyleSheet events are dropped in transit. CSS rules are now serialized inline in the full snapshot so replay is self-contained. Adds a `captureAdoptedStyleSheets` record option (default `true`) to opt out if snapshot size is a concern.

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -940,7 +940,11 @@ function serializeAdoptedStyleSheets(
           index,
         }));
       } catch (e) {
-        // SecurityError: cross-origin stylesheet
+        if (e instanceof DOMException && e.name === 'SecurityError') {
+          // Cross-origin stylesheet: cssRules is intentionally blocked.
+        } else {
+          throw e;
+        }
       }
     }
     return { styleId, rules };

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -1089,7 +1089,10 @@ export function serializeNodeWithId(
     const doc = n as Document;
     if (doc.adoptedStyleSheets?.length) {
       (serializedNode as documentNode).adoptedStyleSheets =
-        serializeAdoptedStyleSheets(doc.adoptedStyleSheets, onAdoptedStyleSheet);
+        serializeAdoptedStyleSheets(
+          doc.adoptedStyleSheets,
+          onAdoptedStyleSheet,
+        );
     }
   }
   if (

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -972,6 +972,7 @@ export function serializeNodeWithId(
     preserveWhiteSpace?: boolean;
     onSerialize?: (n: Node) => unknown;
     onAdoptedStyleSheet?: (sheet: CSSStyleSheet) => number;
+    /** @internal Tracks styleIds whose rules have already been serialized; shared across recursive calls within one document traversal. Not forwarded into iframe documents because CSSStyleSheet instances cannot be shared across browsing contexts. */
     _emittedStyleIds?: Set<number>;
     onIframeLoad?: (
       iframeNode: HTMLIFrameElement,

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -927,14 +927,24 @@ function slimDOMExcluded(
 function serializeAdoptedStyleSheets(
   sheets: CSSStyleSheet[] | readonly CSSStyleSheet[],
   onAdoptedStyleSheet: (sheet: CSSStyleSheet) => number,
+  emittedStyleIds: Set<number>,
 ): serializedAdoptedStyleSheet[] {
-  return Array.from(sheets).map((sheet) => ({
-    styleId: onAdoptedStyleSheet(sheet),
-    rules: Array.from(sheet.cssRules || [], (rule, index) => ({
-      rule: stringifyRule(rule, sheet.href),
-      index,
-    })),
-  }));
+  return Array.from(sheets).map((sheet) => {
+    const styleId = onAdoptedStyleSheet(sheet);
+    let rules: serializedAdoptedStyleSheet['rules'] = [];
+    if (!emittedStyleIds.has(styleId)) {
+      emittedStyleIds.add(styleId);
+      try {
+        rules = Array.from(sheet.cssRules, (rule, index) => ({
+          rule: stringifyRule(rule, sheet.href),
+          index,
+        }));
+      } catch (e) {
+        // SecurityError: cross-origin stylesheet
+      }
+    }
+    return { styleId, rules };
+  });
 }
 
 export function serializeNodeWithId(
@@ -962,6 +972,7 @@ export function serializeNodeWithId(
     preserveWhiteSpace?: boolean;
     onSerialize?: (n: Node) => unknown;
     onAdoptedStyleSheet?: (sheet: CSSStyleSheet) => number;
+    _emittedStyleIds?: Set<number>;
     onIframeLoad?: (
       iframeNode: HTMLIFrameElement,
       node: serializedElementNodeWithId,
@@ -1004,6 +1015,7 @@ export function serializeNodeWithId(
     cssCaptured = false,
     applyBackgroundColorToBlockedElements = false,
   } = options;
+  const emittedStyleIds = options._emittedStyleIds ?? new Set<number>();
   let { needsMask } = options;
   let { preserveWhiteSpace = true } = options;
 
@@ -1081,6 +1093,7 @@ export function serializeNodeWithId(
         serializedNode.adoptedStyleSheets = serializeAdoptedStyleSheets(
           shadowRootEl.adoptedStyleSheets,
           onAdoptedStyleSheet,
+          emittedStyleIds,
         );
       }
     }
@@ -1092,6 +1105,7 @@ export function serializeNodeWithId(
         serializeAdoptedStyleSheets(
           doc.adoptedStyleSheets,
           onAdoptedStyleSheet,
+          emittedStyleIds,
         );
     }
   }
@@ -1129,6 +1143,7 @@ export function serializeNodeWithId(
       preserveWhiteSpace,
       onSerialize,
       onAdoptedStyleSheet,
+      _emittedStyleIds: emittedStyleIds,
       onIframeLoad,
       iframeLoadTimeout,
       onStylesheetLoad,
@@ -1207,6 +1222,7 @@ export function serializeNodeWithId(
             recordCanvas,
             preserveWhiteSpace,
             onSerialize,
+            onAdoptedStyleSheet,
             onIframeLoad,
             iframeLoadTimeout,
             onStylesheetLoad,

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -14,6 +14,8 @@ import type {
   serializedNodeWithId,
   serializedElementNodeWithId,
   elementNode,
+  documentNode,
+  serializedAdoptedStyleSheet,
   attributes,
   mediaAttributes,
   DataURLOptions,
@@ -26,6 +28,7 @@ import {
   maskInputValue,
   isNativeShadowDom,
   stringifyStylesheet,
+  stringifyRule,
   getInputType,
   toLowerCase,
   extractFileExtension,
@@ -921,6 +924,19 @@ function slimDOMExcluded(
   return false;
 }
 
+function serializeAdoptedStyleSheets(
+  sheets: CSSStyleSheet[] | readonly CSSStyleSheet[],
+  onAdoptedStyleSheet: (sheet: CSSStyleSheet) => number,
+): serializedAdoptedStyleSheet[] {
+  return Array.from(sheets).map((sheet) => ({
+    styleId: onAdoptedStyleSheet(sheet),
+    rules: Array.from(sheet.cssRules || [], (rule, index) => ({
+      rule: stringifyRule(rule, sheet.href),
+      index,
+    })),
+  }));
+}
+
 export function serializeNodeWithId(
   n: Node,
   options: {
@@ -945,6 +961,7 @@ export function serializeNodeWithId(
     recordCanvas?: boolean;
     preserveWhiteSpace?: boolean;
     onSerialize?: (n: Node) => unknown;
+    onAdoptedStyleSheet?: (sheet: CSSStyleSheet) => number;
     onIframeLoad?: (
       iframeNode: HTMLIFrameElement,
       node: serializedElementNodeWithId,
@@ -977,6 +994,7 @@ export function serializeNodeWithId(
     inlineImages = false,
     recordCanvas = false,
     onSerialize,
+    onAdoptedStyleSheet,
     onIframeLoad,
     iframeLoadTimeout = 5000,
     onStylesheetLoad,
@@ -1057,8 +1075,22 @@ export function serializeNodeWithId(
     // this property was not needed in replay side
     delete serializedNode.needBlock;
     const shadowRootEl = dom.shadowRoot(n);
-    if (shadowRootEl && isNativeShadowDom(shadowRootEl))
+    if (shadowRootEl && isNativeShadowDom(shadowRootEl)) {
       serializedNode.isShadowHost = true;
+      if (onAdoptedStyleSheet && shadowRootEl.adoptedStyleSheets?.length) {
+        serializedNode.adoptedStyleSheets = serializeAdoptedStyleSheets(
+          shadowRootEl.adoptedStyleSheets,
+          onAdoptedStyleSheet,
+        );
+      }
+    }
+  }
+  if (serializedNode.type === NodeType.Document && onAdoptedStyleSheet) {
+    const doc = n as Document;
+    if (doc.adoptedStyleSheets?.length) {
+      (serializedNode as documentNode).adoptedStyleSheets =
+        serializeAdoptedStyleSheets(doc.adoptedStyleSheets, onAdoptedStyleSheet);
+    }
   }
   if (
     (serializedNode.type === NodeType.Document ||
@@ -1093,6 +1125,7 @@ export function serializeNodeWithId(
       recordCanvas,
       preserveWhiteSpace,
       onSerialize,
+      onAdoptedStyleSheet,
       onIframeLoad,
       iframeLoadTimeout,
       onStylesheetLoad,
@@ -1265,6 +1298,7 @@ function snapshot(
     recordCanvas?: boolean;
     preserveWhiteSpace?: boolean;
     onSerialize?: (n: Node) => unknown;
+    onAdoptedStyleSheet?: (sheet: CSSStyleSheet) => number;
     onIframeLoad?: (
       iframeNode: HTMLIFrameElement,
       node: serializedElementNodeWithId,
@@ -1296,6 +1330,7 @@ function snapshot(
     dataURLOptions,
     preserveWhiteSpace,
     onSerialize,
+    onAdoptedStyleSheet,
     onIframeLoad,
     iframeLoadTimeout,
     onStylesheetLoad,
@@ -1365,6 +1400,7 @@ function snapshot(
     recordCanvas,
     preserveWhiteSpace,
     onSerialize,
+    onAdoptedStyleSheet,
     onIframeLoad,
     iframeLoadTimeout,
     onStylesheetLoad,

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -406,6 +406,7 @@ export function record<T = eventWithTime>(
           shadowDomManager.addShadowRoot(dom.shadowRoot(n as Node)!, document);
         }
       },
+      onAdoptedStyleSheet: (sheet) => stylesheetManager.styleMirror.add(sheet),
       onIframeLoad: (iframe, childSn) => {
         iframeManager.attachIframe(iframe, childSn);
         shadowDomManager.observeAttachShadow(iframe);

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -407,6 +407,8 @@ export function record<T = eventWithTime>(
           shadowDomManager.addShadowRoot(dom.shadowRoot(n as Node)!, document);
         }
       },
+      // stylesheetManager.reset() runs just before snapshot() so styleMirror
+      // ids are always fresh and in sync with the snapshot's serialized styleIds.
       onAdoptedStyleSheet: captureAdoptedStyleSheets
         ? (sheet) => stylesheetManager.styleMirror.add(sheet)
         : undefined,

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -96,6 +96,7 @@ export function record<T = eventWithTime>(
     userTriggeredOnInput = false,
     collectFonts = false,
     inlineImages = false,
+    captureAdoptedStyleSheets = true,
     plugins,
     keepIframeSrcFn = () => false,
     ignoreCSSAttributes = new Set([]),
@@ -406,7 +407,9 @@ export function record<T = eventWithTime>(
           shadowDomManager.addShadowRoot(dom.shadowRoot(n as Node)!, document);
         }
       },
-      onAdoptedStyleSheet: (sheet) => stylesheetManager.styleMirror.add(sheet),
+      onAdoptedStyleSheet: captureAdoptedStyleSheets
+        ? (sheet) => stylesheetManager.styleMirror.add(sheet)
+        : undefined,
       onIframeLoad: (iframe, childSn) => {
         iframeManager.attachIframe(iframe, childSn);
         shadowDomManager.observeAttachShadow(iframe);

--- a/packages/rrweb/src/record/shadow-dom-manager.ts
+++ b/packages/rrweb/src/record/shadow-dom-manager.ts
@@ -143,10 +143,6 @@ export class ShadowDomManager {
     );
   }
 
-  public clearCache() {
-    this.shadowDoms = new WeakSet();
-  }
-
   public reset() {
     this.restoreHandlers.forEach((handler) => {
       try {
@@ -156,6 +152,6 @@ export class ShadowDomManager {
       }
     });
     this.restoreHandlers = [];
-    this.clearCache();
+    this.shadowDoms = new WeakSet();
   }
 }

--- a/packages/rrweb/src/record/shadow-dom-manager.ts
+++ b/packages/rrweb/src/record/shadow-dom-manager.ts
@@ -143,6 +143,10 @@ export class ShadowDomManager {
     );
   }
 
+  public clearCache() {
+    this.shadowDoms = new WeakSet();
+  }
+
   public reset() {
     this.restoreHandlers.forEach((handler) => {
       try {
@@ -152,6 +156,6 @@ export class ShadowDomManager {
       }
     });
     this.restoreHandlers = [];
-    this.shadowDoms = new WeakSet();
+    this.clearCache();
   }
 }

--- a/packages/rrweb/src/record/stylesheet-manager.ts
+++ b/packages/rrweb/src/record/stylesheet-manager.ts
@@ -72,7 +72,11 @@ export class StylesheetManager {
             index,
           }));
         } catch (e) {
-          // SecurityError: cross-origin stylesheet
+          if (e instanceof DOMException && e.name === 'SecurityError') {
+            // Cross-origin stylesheet: cssRules is intentionally blocked.
+          } else {
+            throw e;
+          }
         }
         styles.push({ styleId, rules });
       } else styleId = this.styleMirror.getId(sheet);

--- a/packages/rrweb/src/record/stylesheet-manager.ts
+++ b/packages/rrweb/src/record/stylesheet-manager.ts
@@ -65,13 +65,16 @@ export class StylesheetManager {
       let styleId;
       if (!this.styleMirror.has(sheet)) {
         styleId = this.styleMirror.add(sheet);
-        styles.push({
-          styleId,
-          rules: Array.from(sheet.rules || CSSRule, (r, index) => ({
+        let rules: { rule: string; index: number }[] = [];
+        try {
+          rules = Array.from(sheet.cssRules, (r, index) => ({
             rule: stringifyRule(r, sheet.href),
             index,
-          })),
-        });
+          }));
+        } catch (e) {
+          // SecurityError: cross-origin stylesheet
+        }
+        styles.push({ styleId, rules });
       } else styleId = this.styleMirror.getId(sheet);
       adoptedStyleSheetData.styleIds.push(styleId);
     }

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -73,6 +73,7 @@ import type {
   styleDeclarationData,
   adoptedStyleSheetData,
   serializedElementNodeWithId,
+  serializedAdoptedStyleSheet,
 } from '@amplitude/rrweb-types';
 import {
   polyfill,
@@ -1011,6 +1012,10 @@ export class Replayer {
           event.timestamp - events[0].timestamp,
           this.mirror,
         );
+      }
+      const sn = this.mirror.getMeta(builtNode);
+      if (sn && 'adoptedStyleSheets' in sn && sn.adoptedStyleSheets?.length) {
+        this.applySnapshotAdoptedStyleSheets(builtNode, sn.adoptedStyleSheets);
       }
       for (const plugin of this.config.plugins || []) {
         if (plugin.onBuild)
@@ -2301,6 +2306,39 @@ export class Replayer {
       ) as unknown as CSSStyleRule;
       rule.style.removeProperty(data.remove.property);
     }
+  }
+
+  private applySnapshotAdoptedStyleSheets(
+    node: Node,
+    adoptedStyleSheets: serializedAdoptedStyleSheet[],
+  ) {
+    let hostWindow: IWindow | null = null;
+    if (hasShadowRoot(node))
+      hostWindow = (node as Element).ownerDocument?.defaultView || null;
+    else if (node.nodeName === '#document')
+      hostWindow = (node as Document).defaultView;
+    if (!hostWindow) return;
+
+    const sheets: CSSStyleSheet[] = [];
+    for (const { styleId, rules } of adoptedStyleSheets) {
+      try {
+        const sheet = new hostWindow.CSSStyleSheet();
+        this.styleMirror.add(sheet, styleId);
+        this.applyStyleSheetRule(
+          { source: IncrementalSource.StyleSheetRule, adds: rules },
+          sheet,
+        );
+        sheets.push(sheet);
+      } catch (e) {
+        // browser doesn't support constructing StyleSheet
+      }
+    }
+
+    if (hasShadowRoot(node))
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      (node as HTMLElement).shadowRoot!.adoptedStyleSheets = sheets;
+    else if (node.nodeName === '#document')
+      (node as Document).adoptedStyleSheets = sheets;
   }
 
   private applyAdoptedStyleSheet(data: adoptedStyleSheetData) {

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1188,7 +1188,10 @@ export class Replayer {
       if (!this.usingVirtualDom) {
         const sn = this.mirror.getMeta(builtNode);
         if (sn && 'adoptedStyleSheets' in sn && sn.adoptedStyleSheets?.length) {
-          this.applySnapshotAdoptedStyleSheets(builtNode, sn.adoptedStyleSheets);
+          this.applySnapshotAdoptedStyleSheets(
+            builtNode,
+            sn.adoptedStyleSheets,
+          );
         }
       }
       // Skip the plugin onBuild callback in the virtual dom mode
@@ -2347,8 +2350,7 @@ export class Replayer {
       }
     }
 
-    if (hasShadowRoot(node))
-      node.shadowRoot.adoptedStyleSheets = sheets;
+    if (hasShadowRoot(node)) node.shadowRoot.adoptedStyleSheets = sheets;
     else if (node.nodeName === '#document')
       (node as Document).adoptedStyleSheets = sheets;
   }

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -2323,7 +2323,7 @@ export class Replayer {
   ) {
     let hostWindow: IWindow | null = null;
     if (hasShadowRoot(node))
-      hostWindow = (node as Element).ownerDocument?.defaultView || null;
+      hostWindow = node.ownerDocument?.defaultView || null;
     else if (node.nodeName === '#document')
       hostWindow = (node as Document).defaultView;
     if (!hostWindow) return;

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -967,6 +967,9 @@ export class Replayer {
       if (meta) scratchMirror.add(node, meta);
     });
 
+    // onAdoptedStyleSheet is intentionally omitted: seek-cache snapshots capture
+    // static DOM structure only. AdoptedStyleSheets are re-applied when the
+    // replayer replays incremental events from the seek checkpoint to the target time.
     const snapshotNode = snapshot(this.iframe.contentDocument, {
       mirror: scratchMirror,
       blockClass: this.config.blockClass,

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -187,6 +187,13 @@ export class Replayer {
   // Similar to the reason for constructedStyleMutations.
   private adoptedStyleSheets: adoptedStyleSheetData[] = [];
 
+  // Inline adoptedStyleSheets from iframe documents encountered while usingVirtualDom.
+  // Deferred until the Flush handler materializes real nodes via diff().
+  private snapshotAdoptedStyleSheetQueue: {
+    id: number;
+    adoptedStyleSheets: serializedAdoptedStyleSheet[];
+  }[] = [];
+
   constructor(
     events: Array<eventWithTime | string>,
     config?: Partial<playerConfig>,
@@ -314,6 +321,12 @@ export class Replayer {
           this.applyAdoptedStyleSheet(data);
         });
         this.adoptedStyleSheets = [];
+
+        this.snapshotAdoptedStyleSheetQueue.forEach(({ id, adoptedStyleSheets }) => {
+          const node = this.mirror.getNode(id);
+          if (node) this.applySnapshotAdoptedStyleSheets(node, adoptedStyleSheets);
+        });
+        this.snapshotAdoptedStyleSheetQueue = [];
       }
 
       if (this.mousePos) {
@@ -1188,13 +1201,31 @@ export class Replayer {
         );
       }
 
-      if (!this.usingVirtualDom) {
-        const sn = this.mirror.getMeta(builtNode);
-        if (sn && 'adoptedStyleSheets' in sn && sn.adoptedStyleSheets?.length) {
-          this.applySnapshotAdoptedStyleSheets(
-            builtNode,
-            sn.adoptedStyleSheets,
-          );
+      {
+        const nodeSn = (mirror as TMirror).getMeta(
+          builtNode as unknown as TNode,
+        );
+        if (
+          nodeSn &&
+          'adoptedStyleSheets' in nodeSn &&
+          nodeSn.adoptedStyleSheets?.length
+        ) {
+          if (this.usingVirtualDom) {
+            // In virtual DOM mode the real nodes don't exist yet; defer until
+            // the Flush handler materializes them via diff().
+            const id = (mirror as TMirror).getId(
+              builtNode as unknown as TNode,
+            );
+            this.snapshotAdoptedStyleSheetQueue.push({
+              id,
+              adoptedStyleSheets: nodeSn.adoptedStyleSheets,
+            });
+          } else {
+            this.applySnapshotAdoptedStyleSheets(
+              builtNode,
+              nodeSn.adoptedStyleSheets,
+            );
+          }
         }
       }
       // Skip the plugin onBuild callback in the virtual dom mode
@@ -2335,12 +2366,13 @@ export class Replayer {
     for (const { styleId, rules } of adoptedStyleSheets) {
       const existing = this.styleMirror.getStyle(styleId);
       if (existing) {
-        // Sheet already registered from an earlier host in this snapshot (shared sheet de-dup).
-        // Reuse the same object so all hosts end up with the identical CSSStyleSheet instance.
-        // If this entry carries rules the existing sheet doesn't yet have (post-order replay:
-        // a deeper host's afterAppend fires before its ancestor's, so the ancestor's
-        // rule-carrying entry arrives after the descendant already created an empty sheet),
-        // apply them now so the shared sheet ends up populated.
+        // The recorder de-duplicates shared CSSStyleSheet objects: rules are
+        // emitted once (first encounter, top-down) and subsequent references
+        // carry rules:[]. Because afterAppend fires bottom-up (post-order),
+        // the deeper shadow host's empty entry can register the sheet before
+        // the ancestor's rule-carrying entry arrives. Back-fill the rules
+        // onto the already-registered sheet so the shared instance is fully
+        // populated regardless of which host's afterAppend fires first.
         if (rules.length) {
           this.applyStyleSheetRule(
             { source: IncrementalSource.StyleSheetRule, adds: rules },

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -2332,6 +2332,8 @@ export class Replayer {
     for (const { styleId, rules } of adoptedStyleSheets) {
       const existing = this.styleMirror.getStyle(styleId);
       if (existing) {
+        // Sheet already registered from an earlier host in this snapshot (shared sheet de-dup).
+        // Reuse the same object so all hosts end up with the identical CSSStyleSheet instance.
         sheets.push(existing);
         continue;
       }

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -2337,6 +2337,16 @@ export class Replayer {
       if (existing) {
         // Sheet already registered from an earlier host in this snapshot (shared sheet de-dup).
         // Reuse the same object so all hosts end up with the identical CSSStyleSheet instance.
+        // If this entry carries rules the existing sheet doesn't yet have (post-order replay:
+        // a deeper host's afterAppend fires before its ancestor's, so the ancestor's
+        // rule-carrying entry arrives after the descendant already created an empty sheet),
+        // apply them now so the shared sheet ends up populated.
+        if (rules.length) {
+          this.applyStyleSheetRule(
+            { source: IncrementalSource.StyleSheetRule, adds: rules },
+            existing,
+          );
+        }
         sheets.push(existing);
         continue;
       }

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -322,10 +322,13 @@ export class Replayer {
         });
         this.adoptedStyleSheets = [];
 
-        this.snapshotAdoptedStyleSheetQueue.forEach(({ id, adoptedStyleSheets }) => {
-          const node = this.mirror.getNode(id);
-          if (node) this.applySnapshotAdoptedStyleSheets(node, adoptedStyleSheets);
-        });
+        this.snapshotAdoptedStyleSheetQueue.forEach(
+          ({ id, adoptedStyleSheets }) => {
+            const node = this.mirror.getNode(id);
+            if (node)
+              this.applySnapshotAdoptedStyleSheets(node, adoptedStyleSheets);
+          },
+        );
         this.snapshotAdoptedStyleSheetQueue = [];
       }
 
@@ -1213,9 +1216,7 @@ export class Replayer {
           if (this.usingVirtualDom) {
             // In virtual DOM mode the real nodes don't exist yet; defer until
             // the Flush handler materializes them via diff().
-            const id = (mirror as TMirror).getId(
-              builtNode as unknown as TNode,
-            );
+            const id = (mirror as TMirror).getId(builtNode as unknown as TNode);
             this.snapshotAdoptedStyleSheetQueue.push({
               id,
               adoptedStyleSheets: nodeSn.adoptedStyleSheets,

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1185,6 +1185,12 @@ export class Replayer {
         );
       }
 
+      if (!this.usingVirtualDom) {
+        const sn = this.mirror.getMeta(builtNode);
+        if (sn && 'adoptedStyleSheets' in sn && sn.adoptedStyleSheets?.length) {
+          this.applySnapshotAdoptedStyleSheets(builtNode, sn.adoptedStyleSheets);
+        }
+      }
       // Skip the plugin onBuild callback in the virtual dom mode
       if (this.usingVirtualDom) return;
       for (const plugin of this.config.plugins || []) {
@@ -2321,13 +2327,20 @@ export class Replayer {
 
     const sheets: CSSStyleSheet[] = [];
     for (const { styleId, rules } of adoptedStyleSheets) {
+      const existing = this.styleMirror.getStyle(styleId);
+      if (existing) {
+        sheets.push(existing);
+        continue;
+      }
       try {
         const sheet = new hostWindow.CSSStyleSheet();
         this.styleMirror.add(sheet, styleId);
-        this.applyStyleSheetRule(
-          { source: IncrementalSource.StyleSheetRule, adds: rules },
-          sheet,
-        );
+        if (rules.length) {
+          this.applyStyleSheetRule(
+            { source: IncrementalSource.StyleSheetRule, adds: rules },
+            sheet,
+          );
+        }
         sheets.push(sheet);
       } catch (e) {
         // browser doesn't support constructing StyleSheet
@@ -2335,8 +2348,7 @@ export class Replayer {
     }
 
     if (hasShadowRoot(node))
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      (node as HTMLElement).shadowRoot!.adoptedStyleSheets = sheets;
+      node.shadowRoot.adoptedStyleSheets = sheets;
     else if (node.nodeName === '#document')
       (node as Document).adoptedStyleSheets = sheets;
   }

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -71,6 +71,12 @@ export type recordOptions<T> = {
   userTriggeredOnInput?: boolean;
   collectFonts?: boolean;
   inlineImages?: boolean;
+  /**
+   * When true (default), CSS rules from `adoptedStyleSheets` are serialized
+   * inline in the full snapshot so replay is self-contained even if incremental
+   * AdoptedStyleSheet events are dropped in transit. Set to false if snapshot
+   * size is a concern; the CSS will instead be carried in incremental events.
+   */
   captureAdoptedStyleSheets?: boolean;
   plugins?: RecordPlugin[];
   // departed, please use sampling options

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -71,6 +71,7 @@ export type recordOptions<T> = {
   userTriggeredOnInput?: boolean;
   collectFonts?: boolean;
   inlineImages?: boolean;
+  captureAdoptedStyleSheets?: boolean;
   plugins?: RecordPlugin[];
   // departed, please use sampling options
   mousemoveWait?: number;

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -76,6 +76,11 @@ export type recordOptions<T> = {
    * inline in the full snapshot so replay is self-contained even if incremental
    * AdoptedStyleSheet events are dropped in transit. Set to false if snapshot
    * size is a concern; the CSS will instead be carried in incremental events.
+   *
+   * **Warning:** setting this to `false` increases the risk of unstyled shadow
+   * DOM on replay. Shadow-root `adoptedStyleSheets` are emitted via a
+   * `setTimeout(0)` after the snapshot, so if any incremental events are
+   * dropped in transit those styles will be permanently missing from the replay.
    */
   captureAdoptedStyleSheets?: boolean;
   plugins?: RecordPlugin[];

--- a/packages/rrweb/test/__snapshots__/record.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/record.test.ts.snap
@@ -628,7 +628,18 @@ exports[`record > captures adopted stylesheets in nested shadow doms and iframes
                         \\"childNodes\\": [],
                         \\"rootId\\": 29,
                         \\"id\\": 33,
-                        \\"isShadowHost\\": true
+                        \\"isShadowHost\\": true,
+                        \\"adoptedStyleSheets\\": [
+                          {
+                            \\"styleId\\": 2,
+                            \\"rules\\": [
+                              {
+                                \\"rule\\": \\"div { font-size: large; }\\",
+                                \\"index\\": 0
+                              }
+                            ]
+                          }
+                        ]
                       }
                     ],
                     \\"rootId\\": 29,
@@ -640,7 +651,18 @@ exports[`record > captures adopted stylesheets in nested shadow doms and iframes
               }
             ],
             \\"compatMode\\": \\"BackCompat\\",
-            \\"id\\": 29
+            \\"id\\": 29,
+            \\"adoptedStyleSheets\\": [
+              {
+                \\"styleId\\": 1,
+                \\"rules\\": [
+                  {
+                    \\"rule\\": \\"h1 { color: blue; }\\",
+                    \\"index\\": 0
+                  }
+                ]
+              }
+            ]
           }
         }
       ],
@@ -657,17 +679,6 @@ exports[`record > captures adopted stylesheets in nested shadow doms and iframes
       \\"id\\": 29,
       \\"styleIds\\": [
         1
-      ],
-      \\"styles\\": [
-        {
-          \\"styleId\\": 1,
-          \\"rules\\": [
-            {
-              \\"rule\\": \\"h1 { color: blue; }\\",
-              \\"index\\": 0
-            }
-          ]
-        }
       ]
     }
   },
@@ -678,17 +689,6 @@ exports[`record > captures adopted stylesheets in nested shadow doms and iframes
       \\"id\\": 33,
       \\"styleIds\\": [
         2
-      ],
-      \\"styles\\": [
-        {
-          \\"styleId\\": 2,
-          \\"rules\\": [
-            {
-              \\"rule\\": \\"div { font-size: large; }\\",
-              \\"index\\": 0
-            }
-          ]
-        }
       ]
     }
   },
@@ -853,20 +853,7 @@ exports[`record > captures adopted stylesheets in shadow doms and iframe 1`] = `
                     \\"adoptedStyleSheets\\": [
                       {
                         \\"styleId\\": 1,
-                        \\"rules\\": [
-                          {
-                            \\"rule\\": \\"div { color: yellow; }\\",
-                            \\"index\\": 0
-                          },
-                          {
-                            \\"rule\\": \\"h2 { color: orange; }\\",
-                            \\"index\\": 1
-                          },
-                          {
-                            \\"rule\\": \\"h3 { font-size: larger; }\\",
-                            \\"index\\": 2
-                          }
-                        ]
+                        \\"rules\\": []
                       },
                       {
                         \\"styleId\\": 2,
@@ -1019,7 +1006,18 @@ exports[`record > captures adopted stylesheets in shadow doms and iframe 1`] = `
               }
             ],
             \\"compatMode\\": \\"BackCompat\\",
-            \\"id\\": 20
+            \\"id\\": 20,
+            \\"adoptedStyleSheets\\": [
+              {
+                \\"styleId\\": 3,
+                \\"rules\\": [
+                  {
+                    \\"rule\\": \\"h1 { color: blue; }\\",
+                    \\"index\\": 0
+                  }
+                ]
+              }
+            ]
           }
         }
       ],
@@ -1036,17 +1034,6 @@ exports[`record > captures adopted stylesheets in shadow doms and iframe 1`] = `
       \\"id\\": 20,
       \\"styleIds\\": [
         3
-      ],
-      \\"styles\\": [
-        {
-          \\"styleId\\": 3,
-          \\"rules\\": [
-            {
-              \\"rule\\": \\"h1 { color: blue; }\\",
-              \\"index\\": 0
-            }
-          ]
-        }
       ]
     }
   },
@@ -1655,7 +1642,13 @@ exports[`record > captures mutations on adopted stylesheets 1`] = `
               }
             ],
             \\"compatMode\\": \\"BackCompat\\",
-            \\"id\\": 12
+            \\"id\\": 12,
+            \\"adoptedStyleSheets\\": [
+              {
+                \\"styleId\\": 2,
+                \\"rules\\": []
+              }
+            ]
           }
         }
       ],
@@ -1672,12 +1665,6 @@ exports[`record > captures mutations on adopted stylesheets 1`] = `
       \\"id\\": 12,
       \\"styleIds\\": [
         2
-      ],
-      \\"styles\\": [
-        {
-          \\"styleId\\": 2,
-          \\"rules\\": []
-        }
       ]
     }
   },

--- a/packages/rrweb/test/__snapshots__/record.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/record.test.ts.snap
@@ -849,7 +849,35 @@ exports[`record > captures adopted stylesheets in shadow doms and iframe 1`] = `
                       }
                     ],
                     \\"id\\": 10,
-                    \\"isShadowHost\\": true
+                    \\"isShadowHost\\": true,
+                    \\"adoptedStyleSheets\\": [
+                      {
+                        \\"styleId\\": 1,
+                        \\"rules\\": [
+                          {
+                            \\"rule\\": \\"div { color: yellow; }\\",
+                            \\"index\\": 0
+                          },
+                          {
+                            \\"rule\\": \\"h2 { color: orange; }\\",
+                            \\"index\\": 1
+                          },
+                          {
+                            \\"rule\\": \\"h3 { font-size: larger; }\\",
+                            \\"index\\": 2
+                          }
+                        ]
+                      },
+                      {
+                        \\"styleId\\": 2,
+                        \\"rules\\": [
+                          {
+                            \\"rule\\": \\"span { color: red; }\\",
+                            \\"index\\": 0
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
                     \\"type\\": 3,
@@ -889,7 +917,26 @@ exports[`record > captures adopted stylesheets in shadow doms and iframe 1`] = `
             \\"id\\": 3
           }
         ],
-        \\"id\\": 1
+        \\"id\\": 1,
+        \\"adoptedStyleSheets\\": [
+          {
+            \\"styleId\\": 1,
+            \\"rules\\": [
+              {
+                \\"rule\\": \\"div { color: yellow; }\\",
+                \\"index\\": 0
+              },
+              {
+                \\"rule\\": \\"h2 { color: orange; }\\",
+                \\"index\\": 1
+              },
+              {
+                \\"rule\\": \\"h3 { font-size: larger; }\\",
+                \\"index\\": 2
+              }
+            ]
+          }
+        ]
       },
       \\"initialOffset\\": {
         \\"left\\": 0,
@@ -904,25 +951,6 @@ exports[`record > captures adopted stylesheets in shadow doms and iframe 1`] = `
       \\"id\\": 1,
       \\"styleIds\\": [
         1
-      ],
-      \\"styles\\": [
-        {
-          \\"styleId\\": 1,
-          \\"rules\\": [
-            {
-              \\"rule\\": \\"div { color: yellow; }\\",
-              \\"index\\": 0
-            },
-            {
-              \\"rule\\": \\"h2 { color: orange; }\\",
-              \\"index\\": 1
-            },
-            {
-              \\"rule\\": \\"h3 { font-size: larger; }\\",
-              \\"index\\": 2
-            }
-          ]
-        }
       ]
     }
   },
@@ -934,17 +962,6 @@ exports[`record > captures adopted stylesheets in shadow doms and iframe 1`] = `
       \\"styleIds\\": [
         1,
         2
-      ],
-      \\"styles\\": [
-        {
-          \\"styleId\\": 2,
-          \\"rules\\": [
-            {
-              \\"rule\\": \\"span { color: red; }\\",
-              \\"index\\": 0
-            }
-          ]
-        }
       ]
     }
   },
@@ -1204,7 +1221,18 @@ exports[`record > captures adopted stylesheets of shadow doms in checkout full s
                       }
                     ],
                     \\"id\\": 7,
-                    \\"isShadowHost\\": true
+                    \\"isShadowHost\\": true,
+                    \\"adoptedStyleSheets\\": [
+                      {
+                        \\"styleId\\": 1,
+                        \\"rules\\": [
+                          {
+                            \\"rule\\": \\"h1 { color: blue; }\\",
+                            \\"index\\": 0
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
                     \\"type\\": 3,
@@ -1233,17 +1261,6 @@ exports[`record > captures adopted stylesheets of shadow doms in checkout full s
       \\"id\\": 7,
       \\"styleIds\\": [
         1
-      ],
-      \\"styles\\": [
-        {
-          \\"styleId\\": 1,
-          \\"rules\\": [
-            {
-              \\"rule\\": \\"h1 { color: blue; }\\",
-              \\"index\\": 0
-            }
-          ]
-        }
       ]
     }
   },
@@ -1304,7 +1321,18 @@ exports[`record > captures adopted stylesheets of shadow doms in checkout full s
                       }
                     ],
                     \\"id\\": 7,
-                    \\"isShadowHost\\": true
+                    \\"isShadowHost\\": true,
+                    \\"adoptedStyleSheets\\": [
+                      {
+                        \\"styleId\\": 1,
+                        \\"rules\\": [
+                          {
+                            \\"rule\\": \\"h1 { color: blue; }\\",
+                            \\"index\\": 0
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
                     \\"type\\": 3,
@@ -1333,17 +1361,6 @@ exports[`record > captures adopted stylesheets of shadow doms in checkout full s
       \\"id\\": 7,
       \\"styleIds\\": [
         1
-      ],
-      \\"styles\\": [
-        {
-          \\"styleId\\": 1,
-          \\"rules\\": [
-            {
-              \\"rule\\": \\"h1 { color: blue; }\\",
-              \\"index\\": 0
-            }
-          ]
-        }
       ]
     }
   }
@@ -1560,7 +1577,13 @@ exports[`record > captures mutations on adopted stylesheets 1`] = `
             \\"id\\": 3
           }
         ],
-        \\"id\\": 1
+        \\"id\\": 1,
+        \\"adoptedStyleSheets\\": [
+          {
+            \\"styleId\\": 1,
+            \\"rules\\": []
+          }
+        ]
       },
       \\"initialOffset\\": {
         \\"left\\": 0,
@@ -1575,12 +1598,6 @@ exports[`record > captures mutations on adopted stylesheets 1`] = `
       \\"id\\": 1,
       \\"styleIds\\": [
         1
-      ],
-      \\"styles\\": [
-        {
-          \\"styleId\\": 1,
-          \\"rules\\": []
-        }
       ]
     }
   },

--- a/packages/rrweb/test/events/adopted-style-sheet-in-snapshot.ts
+++ b/packages/rrweb/test/events/adopted-style-sheet-in-snapshot.ts
@@ -28,7 +28,13 @@ const events: eventWithTime[] = [
             tagName: 'html',
             attributes: {},
             childNodes: [
-              { type: 2, tagName: 'head', attributes: {}, childNodes: [], id: 4 },
+              {
+                type: 2,
+                tagName: 'head',
+                attributes: {},
+                childNodes: [],
+                id: 4,
+              },
               {
                 type: 2,
                 tagName: 'body',
@@ -74,7 +80,9 @@ const events: eventWithTime[] = [
         adoptedStyleSheets: [
           {
             styleId: 2,
-            rules: [{ rule: 'body { background-color: rgb(0, 128, 0); }', index: 0 }],
+            rules: [
+              { rule: 'body { background-color: rgb(0, 128, 0); }', index: 0 },
+            ],
           },
         ],
       },

--- a/packages/rrweb/test/events/adopted-style-sheet-in-snapshot.ts
+++ b/packages/rrweb/test/events/adopted-style-sheet-in-snapshot.ts
@@ -1,0 +1,99 @@
+import type { eventWithTime } from '@amplitude/rrweb-types';
+import { EventType, IncrementalSource } from '@amplitude/rrweb-types';
+
+/**
+ * Events where adoptedStyleSheets CSS content is embedded inline in the full
+ * snapshot (new behavior), with NO subsequent incremental AdoptedStyleSheet
+ * events carrying CSS rules. This simulates the case where incremental events
+ * were dropped in transit but the snapshot itself is self-contained.
+ */
+const now = Date.now();
+
+const events: eventWithTime[] = [
+  { type: EventType.DomContentLoaded, data: {}, timestamp: now },
+  {
+    type: EventType.Meta,
+    data: { href: 'about:blank', width: 1920, height: 1080 },
+    timestamp: now + 100,
+  },
+  {
+    type: EventType.FullSnapshot,
+    data: {
+      node: {
+        type: 0,
+        childNodes: [
+          { type: 1, name: 'html', publicId: '', systemId: '', id: 2 },
+          {
+            type: 2,
+            tagName: 'html',
+            attributes: {},
+            childNodes: [
+              { type: 2, tagName: 'head', attributes: {}, childNodes: [], id: 4 },
+              {
+                type: 2,
+                tagName: 'body',
+                attributes: {},
+                childNodes: [
+                  { type: 3, textContent: '\n      ', id: 6 },
+                  {
+                    type: 2,
+                    tagName: 'div',
+                    attributes: { id: 'shadow-host' },
+                    childNodes: [
+                      {
+                        type: 2,
+                        tagName: 'span',
+                        attributes: {},
+                        childNodes: [
+                          { type: 3, textContent: 'text in shadow dom', id: 9 },
+                        ],
+                        id: 8,
+                        isShadow: true,
+                      },
+                    ],
+                    id: 7,
+                    isShadowHost: true,
+                    // CSS content embedded inline — no incremental events needed
+                    adoptedStyleSheets: [
+                      {
+                        styleId: 1,
+                        rules: [{ rule: 'span { color: red; }', index: 0 }],
+                      },
+                    ],
+                  },
+                  { type: 3, textContent: '\n    ', id: 10 },
+                ],
+                id: 5,
+              },
+            ],
+            id: 3,
+          },
+        ],
+        id: 1,
+        // document-level adoptedStyleSheet embedded inline
+        adoptedStyleSheets: [
+          {
+            styleId: 2,
+            rules: [{ rule: 'body { background-color: rgb(0, 128, 0); }', index: 0 }],
+          },
+        ],
+      },
+      initialOffset: { left: 0, top: 0 },
+    },
+    timestamp: now + 100,
+  },
+  // Subsequent event re-adopts using styleIds only (no CSS rules) — simulating
+  // what happens after the initial snapshot when incremental events reference
+  // sheets already known from the snapshot.
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.AdoptedStyleSheet,
+      id: 7,
+      styleIds: [1],
+    },
+    timestamp: now + 200,
+  },
+];
+
+export default events;

--- a/packages/rrweb/test/events/adopted-style-sheet-nested-shared-in-snapshot.ts
+++ b/packages/rrweb/test/events/adopted-style-sheet-nested-shared-in-snapshot.ts
@@ -30,7 +30,13 @@ const events: eventWithTime[] = [
             tagName: 'html',
             attributes: {},
             childNodes: [
-              { type: 2, tagName: 'head', attributes: {}, childNodes: [], id: 4 },
+              {
+                type: 2,
+                tagName: 'head',
+                attributes: {},
+                childNodes: [],
+                id: 4,
+              },
               {
                 type: 2,
                 tagName: 'body',

--- a/packages/rrweb/test/events/adopted-style-sheet-nested-shared-in-snapshot.ts
+++ b/packages/rrweb/test/events/adopted-style-sheet-nested-shared-in-snapshot.ts
@@ -1,0 +1,110 @@
+import type { eventWithTime } from '@amplitude/rrweb-types';
+import { EventType } from '@amplitude/rrweb-types';
+
+/**
+ * Tests the post-order replay hazard: the outer shadow host's adoptedStyleSheets
+ * carry the full rules (serialized first by the recorder, top-down), but the inner
+ * shadow host's carry rules:[] (serialized second, de-duped). During replay,
+ * afterAppend fires bottom-up, so the inner host is processed first — creating an
+ * empty CSSStyleSheet under styleId 1 — before the outer host's rules arrive.
+ * The replayer must back-fill the rules onto the existing shared sheet.
+ */
+const now = Date.now();
+
+const events: eventWithTime[] = [
+  { type: EventType.DomContentLoaded, data: {}, timestamp: now },
+  {
+    type: EventType.Meta,
+    data: { href: 'about:blank', width: 1920, height: 1080 },
+    timestamp: now + 100,
+  },
+  {
+    type: EventType.FullSnapshot,
+    data: {
+      node: {
+        type: 0,
+        childNodes: [
+          { type: 1, name: 'html', publicId: '', systemId: '', id: 2 },
+          {
+            type: 2,
+            tagName: 'html',
+            attributes: {},
+            childNodes: [
+              { type: 2, tagName: 'head', attributes: {}, childNodes: [], id: 4 },
+              {
+                type: 2,
+                tagName: 'body',
+                attributes: {},
+                childNodes: [
+                  { type: 3, textContent: '\n  ', id: 6 },
+                  {
+                    type: 2,
+                    tagName: 'div',
+                    attributes: { id: 'outer-host' },
+                    childNodes: [
+                      // inner shadow host — nested inside outer's shadow root
+                      {
+                        type: 2,
+                        tagName: 'div',
+                        attributes: { id: 'inner-host' },
+                        childNodes: [
+                          {
+                            type: 2,
+                            tagName: 'span',
+                            attributes: {},
+                            childNodes: [
+                              {
+                                type: 3,
+                                textContent: 'inner span',
+                                id: 10,
+                              },
+                            ],
+                            id: 9,
+                            isShadow: true,
+                          },
+                        ],
+                        id: 8,
+                        isShadow: true,
+                        isShadowHost: true,
+                        // Second encounter of styleId 1 — rules: [] (recorder de-dup)
+                        adoptedStyleSheets: [{ styleId: 1, rules: [] }],
+                      },
+                      // span directly in outer shadow root
+                      {
+                        type: 2,
+                        tagName: 'span',
+                        attributes: {},
+                        childNodes: [
+                          { type: 3, textContent: 'outer span', id: 12 },
+                        ],
+                        id: 11,
+                        isShadow: true,
+                      },
+                    ],
+                    id: 7,
+                    isShadowHost: true,
+                    // First encounter of styleId 1 — full rules emitted by recorder
+                    adoptedStyleSheets: [
+                      {
+                        styleId: 1,
+                        rules: [{ rule: 'span { color: red; }', index: 0 }],
+                      },
+                    ],
+                  },
+                  { type: 3, textContent: '\n', id: 13 },
+                ],
+                id: 5,
+              },
+            ],
+            id: 3,
+          },
+        ],
+        id: 1,
+      },
+      initialOffset: { left: 0, top: 0 },
+    },
+    timestamp: now + 100,
+  },
+];
+
+export default events;

--- a/packages/rrweb/test/events/adopted-style-sheet-shared-in-snapshot.ts
+++ b/packages/rrweb/test/events/adopted-style-sheet-shared-in-snapshot.ts
@@ -28,7 +28,13 @@ const events: eventWithTime[] = [
             tagName: 'html',
             attributes: {},
             childNodes: [
-              { type: 2, tagName: 'head', attributes: {}, childNodes: [], id: 4 },
+              {
+                type: 2,
+                tagName: 'head',
+                attributes: {},
+                childNodes: [],
+                id: 4,
+              },
               {
                 type: 2,
                 tagName: 'body',

--- a/packages/rrweb/test/events/adopted-style-sheet-shared-in-snapshot.ts
+++ b/packages/rrweb/test/events/adopted-style-sheet-shared-in-snapshot.ts
@@ -1,0 +1,107 @@
+import type { eventWithTime } from '@amplitude/rrweb-types';
+import { EventType } from '@amplitude/rrweb-types';
+
+/**
+ * Events where two shadow hosts share the same CSSStyleSheet (styleId 1).
+ * The first host carries the full rules; the second carries rules: [] because
+ * the recorder de-duplicates and only emits rules once per styleId.
+ * The replayer should reuse the same CSSStyleSheet object for both hosts.
+ */
+const now = Date.now();
+
+const events: eventWithTime[] = [
+  { type: EventType.DomContentLoaded, data: {}, timestamp: now },
+  {
+    type: EventType.Meta,
+    data: { href: 'about:blank', width: 1920, height: 1080 },
+    timestamp: now + 100,
+  },
+  {
+    type: EventType.FullSnapshot,
+    data: {
+      node: {
+        type: 0,
+        childNodes: [
+          { type: 1, name: 'html', publicId: '', systemId: '', id: 2 },
+          {
+            type: 2,
+            tagName: 'html',
+            attributes: {},
+            childNodes: [
+              { type: 2, tagName: 'head', attributes: {}, childNodes: [], id: 4 },
+              {
+                type: 2,
+                tagName: 'body',
+                attributes: {},
+                childNodes: [
+                  { type: 3, textContent: '\n  ', id: 6 },
+                  {
+                    type: 2,
+                    tagName: 'div',
+                    attributes: { id: 'shadow-host-1' },
+                    childNodes: [
+                      {
+                        type: 2,
+                        tagName: 'span',
+                        attributes: {},
+                        childNodes: [
+                          { type: 3, textContent: 'text in shadow 1', id: 9 },
+                        ],
+                        id: 8,
+                        isShadow: true,
+                      },
+                    ],
+                    id: 7,
+                    isShadowHost: true,
+                    // First encounter: full rules emitted
+                    adoptedStyleSheets: [
+                      {
+                        styleId: 1,
+                        rules: [{ rule: 'span { color: red; }', index: 0 }],
+                      },
+                    ],
+                  },
+                  { type: 3, textContent: '\n  ', id: 10 },
+                  {
+                    type: 2,
+                    tagName: 'div',
+                    attributes: { id: 'shadow-host-2' },
+                    childNodes: [
+                      {
+                        type: 2,
+                        tagName: 'span',
+                        attributes: {},
+                        childNodes: [
+                          { type: 3, textContent: 'text in shadow 2', id: 13 },
+                        ],
+                        id: 12,
+                        isShadow: true,
+                      },
+                    ],
+                    id: 11,
+                    isShadowHost: true,
+                    // Second encounter: rules: [] because recorder de-duplicated
+                    adoptedStyleSheets: [
+                      {
+                        styleId: 1,
+                        rules: [],
+                      },
+                    ],
+                  },
+                  { type: 3, textContent: '\n', id: 14 },
+                ],
+                id: 5,
+              },
+            ],
+            id: 3,
+          },
+        ],
+        id: 1,
+      },
+      initialOffset: { left: 0, top: 0 },
+    },
+    timestamp: now + 100,
+  },
+];
+
+export default events;

--- a/packages/rrweb/test/record.test.ts
+++ b/packages/rrweb/test/record.test.ts
@@ -716,7 +716,9 @@ describe('record', function (this: ISuite) {
       }
       return null;
     };
-    expect(findNode(fullSnapshot!.data.node)?.adoptedStyleSheets).toBeUndefined();
+    expect(
+      findNode(fullSnapshot!.data.node)?.adoptedStyleSheets,
+    ).toBeUndefined();
 
     // An incremental AdoptedStyleSheet event with CSS rules must be emitted instead
     const hasIncrementalWithRules = ctx.events.some(

--- a/packages/rrweb/test/record.test.ts
+++ b/packages/rrweb/test/record.test.ts
@@ -686,6 +686,48 @@ describe('record', function (this: ISuite) {
     await assertSnapshot(ctx.events);
   });
 
+  it('does not inline adoptedStyleSheets when captureAdoptedStyleSheets is false', async () => {
+    await ctx.page.evaluate(() => {
+      return new Promise((resolve) => {
+        const host = document.createElement('div');
+        host.id = 'adopted-host';
+        document.body.appendChild(host);
+        host.attachShadow({ mode: 'open' });
+        const sheet = new CSSStyleSheet();
+        sheet.replaceSync!('span { color: red; }');
+        host.shadowRoot!.adoptedStyleSheets = [sheet];
+
+        const { rrweb, emit } = window as unknown as IWindow;
+        rrweb.record({ emit, captureAdoptedStyleSheets: false });
+        setTimeout(resolve, 50);
+      });
+    });
+    await waitForRAF(ctx.page);
+
+    // Full snapshot must NOT carry adoptedStyleSheets inline on the shadow host
+    const fullSnapshot = ctx.events.find(
+      (e) => e.type === EventType.FullSnapshot,
+    ) as eventWithTime & { data: { node: any } };
+    const findNode = (node: any): any => {
+      if (node?.attributes?.id === 'adopted-host') return node;
+      for (const child of node?.childNodes || []) {
+        const found = findNode(child);
+        if (found) return found;
+      }
+      return null;
+    };
+    expect(findNode(fullSnapshot!.data.node)?.adoptedStyleSheets).toBeUndefined();
+
+    // An incremental AdoptedStyleSheet event with CSS rules must be emitted instead
+    const hasIncrementalWithRules = ctx.events.some(
+      (e) =>
+        e.type === EventType.IncrementalSnapshot &&
+        (e.data as any).source === IncrementalSource.AdoptedStyleSheet &&
+        ((e.data as any).styles ?? []).length > 0,
+    );
+    expect(hasIncrementalWithRules).toBe(true);
+  });
+
   it('captures stylesheets in iframes with `blob:` url', async () => {
     await ctx.page.evaluate(() => {
       const iframe = document.createElement('iframe');

--- a/packages/rrweb/test/replayer.test.ts
+++ b/packages/rrweb/test/replayer.test.ts
@@ -6,6 +6,7 @@ import type * as puppeteer from 'puppeteer';
 import { vi } from 'vitest';
 import adoptedStyleSheet from './events/adopted-style-sheet';
 import adoptedStyleSheetInSnapshot from './events/adopted-style-sheet-in-snapshot';
+import adoptedStyleSheetSharedInSnapshot from './events/adopted-style-sheet-shared-in-snapshot';
 import adoptedStyleSheetModification from './events/adopted-style-sheet-modification';
 import canvasInIframe from './events/canvas-in-iframe';
 import documentReplacementEvents from './events/document-replacement';
@@ -1085,6 +1086,53 @@ describe('replayer', function () {
     await waitForRAF(page);
     await page.evaluate('replayer.pause(300);');
     await checkCorrectness();
+  });
+
+  it('reuses the same CSSStyleSheet object when two shadow hosts share a styleId', async () => {
+    await page.evaluate(`
+      events = ${JSON.stringify(adoptedStyleSheetSharedInSnapshot)};
+      const { Replayer } = rrweb;
+      var replayer = new Replayer(events, { showDebug: true });
+      replayer.play();
+    `);
+    await page.waitForTimeout(300);
+    const iframe = await page.$('iframe');
+    const contentDocument = await iframe!.contentFrame()!;
+
+    // Both shadow roots should have the rule applied (span is red)
+    expect(
+      await contentDocument!.evaluate(
+        () =>
+          window.getComputedStyle(
+            document
+              .querySelector('#shadow-host-1')!
+              .shadowRoot!.querySelector('span')!,
+          ).color,
+      ),
+    ).toEqual('rgb(255, 0, 0)');
+
+    expect(
+      await contentDocument!.evaluate(
+        () =>
+          window.getComputedStyle(
+            document
+              .querySelector('#shadow-host-2')!
+              .shadowRoot!.querySelector('span')!,
+          ).color,
+      ),
+    ).toEqual('rgb(255, 0, 0)');
+
+    // The replayer must reuse the same CSSStyleSheet object for both hosts
+    // (de-dup path: second host has rules: [] and looks up the sheet by styleId)
+    expect(
+      await contentDocument!.evaluate(
+        () =>
+          document.querySelector('#shadow-host-1')!.shadowRoot!
+            .adoptedStyleSheets[0] ===
+          document.querySelector('#shadow-host-2')!.shadowRoot!
+            .adoptedStyleSheets[0],
+      ),
+    ).toBe(true);
   });
 
   it('should replay document replacement events without warnings or errors', async () => {

--- a/packages/rrweb/test/replayer.test.ts
+++ b/packages/rrweb/test/replayer.test.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import type * as puppeteer from 'puppeteer';
 import { vi } from 'vitest';
 import adoptedStyleSheet from './events/adopted-style-sheet';
+import adoptedStyleSheetInSnapshot from './events/adopted-style-sheet-in-snapshot';
 import adoptedStyleSheetModification from './events/adopted-style-sheet-modification';
 import canvasInIframe from './events/canvas-in-iframe';
 import documentReplacementEvents from './events/document-replacement';
@@ -1044,6 +1045,44 @@ describe('replayer', function () {
 
     await page.evaluate('replayer.pause(630);');
     await check600ms();
+  });
+
+  it('can replay adoptedStyleSheets embedded inline in the full snapshot', async () => {
+    await page.evaluate(`
+      events = ${JSON.stringify(adoptedStyleSheetInSnapshot)};
+      const { Replayer } = rrweb;
+      var replayer = new Replayer(events, { showDebug: true });
+      replayer.play();
+    `);
+    await page.waitForTimeout(300);
+    const iframe = await page.$('iframe');
+    const contentDocument = await iframe!.contentFrame()!;
+
+    const checkCorrectness = async () => {
+      // Shadow root's adoptedStyleSheet (styleId 1) serialized inline in snapshot
+      expect(
+        await contentDocument!.evaluate(
+          () =>
+            window.getComputedStyle(
+              document.querySelector('#shadow-host')!.shadowRoot!.querySelector('span')!,
+            ).color,
+        ),
+      ).toEqual('rgb(255, 0, 0)');
+
+      // Document-level adoptedStyleSheet (styleId 2) serialized inline in snapshot
+      expect(
+        await contentDocument!.evaluate(
+          () => window.getComputedStyle(document.body).backgroundColor,
+        ),
+      ).toEqual('rgb(0, 128, 0)');
+    };
+    await checkCorrectness();
+
+    // Verify correctness also holds in fast-forward mode
+    await page.evaluate('replayer.play(0);');
+    await waitForRAF(page);
+    await page.evaluate('replayer.pause(300);');
+    await checkCorrectness();
   });
 
   it('should replay document replacement events without warnings or errors', async () => {

--- a/packages/rrweb/test/replayer.test.ts
+++ b/packages/rrweb/test/replayer.test.ts
@@ -7,6 +7,7 @@ import { vi } from 'vitest';
 import adoptedStyleSheet from './events/adopted-style-sheet';
 import adoptedStyleSheetInSnapshot from './events/adopted-style-sheet-in-snapshot';
 import adoptedStyleSheetSharedInSnapshot from './events/adopted-style-sheet-shared-in-snapshot';
+import adoptedStyleSheetNestedSharedInSnapshot from './events/adopted-style-sheet-nested-shared-in-snapshot';
 import adoptedStyleSheetModification from './events/adopted-style-sheet-modification';
 import canvasInIframe from './events/canvas-in-iframe';
 import documentReplacementEvents from './events/document-replacement';
@@ -1132,6 +1133,58 @@ describe('replayer', function () {
           document.querySelector('#shadow-host-2')!.shadowRoot!
             .adoptedStyleSheets[0],
       ),
+    ).toBe(true);
+  });
+
+  it('applies rules to shared sheet even when inner host afterAppend fires before outer (post-order)', async () => {
+    await page.evaluate(`
+      events = ${JSON.stringify(adoptedStyleSheetNestedSharedInSnapshot)};
+      const { Replayer } = rrweb;
+      var replayer = new Replayer(events, { showDebug: true });
+      replayer.play();
+    `);
+    await page.waitForTimeout(300);
+    const iframe = await page.$('iframe');
+    const contentDocument = await iframe!.contentFrame()!;
+
+    // #inner-host lives inside #outer-host's shadow root — must traverse to reach it
+    // Outer shadow root span must be red
+    expect(
+      await contentDocument!.evaluate(
+        () =>
+          window.getComputedStyle(
+            (document.querySelector('#outer-host') as HTMLElement)
+              .shadowRoot!.querySelector('span')!,
+          ).color,
+      ),
+    ).toEqual('rgb(255, 0, 0)');
+
+    // Inner shadow root span must also be red (post-order fix: rules back-filled)
+    expect(
+      await contentDocument!.evaluate(() => {
+        const innerHost = (
+          document.querySelector('#outer-host') as HTMLElement
+        ).shadowRoot!.querySelector('#inner-host') as HTMLElement;
+        return window.getComputedStyle(
+          innerHost.shadowRoot!.querySelector('span')!,
+        ).color;
+      }),
+    ).toEqual('rgb(255, 0, 0)');
+
+    // Outer and inner shadow roots must share the same CSSStyleSheet object
+    expect(
+      await contentDocument!.evaluate(() => {
+        const outerRoot = (
+          document.querySelector('#outer-host') as HTMLElement
+        ).shadowRoot!;
+        const innerHost = outerRoot.querySelector(
+          '#inner-host',
+        ) as HTMLElement;
+        return (
+          outerRoot.adoptedStyleSheets[0] ===
+          innerHost.shadowRoot!.adoptedStyleSheets[0]
+        );
+      }),
     ).toBe(true);
   });
 

--- a/packages/rrweb/test/replayer.test.ts
+++ b/packages/rrweb/test/replayer.test.ts
@@ -1153,8 +1153,9 @@ describe('replayer', function () {
       await contentDocument!.evaluate(
         () =>
           window.getComputedStyle(
-            (document.querySelector('#outer-host') as HTMLElement)
-              .shadowRoot!.querySelector('span')!,
+            (
+              document.querySelector('#outer-host') as HTMLElement
+            ).shadowRoot!.querySelector('span')!,
           ).color,
       ),
     ).toEqual('rgb(255, 0, 0)');
@@ -1174,12 +1175,9 @@ describe('replayer', function () {
     // Outer and inner shadow roots must share the same CSSStyleSheet object
     expect(
       await contentDocument!.evaluate(() => {
-        const outerRoot = (
-          document.querySelector('#outer-host') as HTMLElement
-        ).shadowRoot!;
-        const innerHost = outerRoot.querySelector(
-          '#inner-host',
-        ) as HTMLElement;
+        const outerRoot = (document.querySelector('#outer-host') as HTMLElement)
+          .shadowRoot!;
+        const innerHost = outerRoot.querySelector('#inner-host') as HTMLElement;
         return (
           outerRoot.adoptedStyleSheets[0] ===
           innerHost.shadowRoot!.adoptedStyleSheets[0]

--- a/packages/rrweb/test/replayer.test.ts
+++ b/packages/rrweb/test/replayer.test.ts
@@ -1064,7 +1064,9 @@ describe('replayer', function () {
         await contentDocument!.evaluate(
           () =>
             window.getComputedStyle(
-              document.querySelector('#shadow-host')!.shadowRoot!.querySelector('span')!,
+              document
+                .querySelector('#shadow-host')!
+                .shadowRoot!.querySelector('span')!,
             ).color,
         ),
       ).toEqual('rgb(255, 0, 0)');

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -726,10 +726,16 @@ export enum NodeType {
   Comment,
 }
 
+export type serializedAdoptedStyleSheet = {
+  styleId: number;
+  rules: styleSheetAddRule[];
+};
+
 export type documentNode = {
   type: NodeType.Document;
   childNodes: serializedNodeWithId[];
   compatMode?: string;
+  adoptedStyleSheets?: serializedAdoptedStyleSheet[];
 };
 
 export type documentTypeNode = {
@@ -789,6 +795,7 @@ export type elementNode = {
   needBlock?: boolean;
   // This is a custom element or not.
   isCustom?: true;
+  adoptedStyleSheets?: serializedAdoptedStyleSheet[];
 };
 
 export type textNode = {


### PR DESCRIPTION
## Problem

Adopted stylesheets on shadow roots were serialized as **separate incremental events** (`IncrementalSource.AdoptedStyleSheet`, source 15) emitted via `setTimeout(0)` after the full snapshot. If those events were dropped in transit before reaching the server, subsequent events referencing the same `styleId`s would arrive without CSS content — leaving shadow DOM styles permanently unapplied in the replayer.

We confirmed this in production recordings: `AdoptedStyleSheet` events reference `styleIds: [1, 7]` with no `styles` array, but no prior event in the stream ever defines those styleIds with their CSS rules.

## Fix

Serialize the CSS content of `adoptedStyleSheets` **directly into the full snapshot node data** for both shadow host elements and document nodes.

### Recorder (`packages/rrweb-snapshot/src/snapshot.ts`, `packages/rrweb/src/record/`)
- Added `serializeAdoptedStyleSheets` helper that serializes CSS rules inline. A shared `CSSStyleSheet` object referenced by multiple shadow roots emits rules only on the **first encounter** (de-duplicated via `_emittedStyleIds: Set<number>` threaded through `serializeNodeWithId` bypassOptions); subsequent references carry `rules: []`.
- Added `captureAdoptedStyleSheets` record option (default `true`). Set to `false` to opt out if snapshot size is a concern — but see the JSDoc warning about the race window this introduces.
- `stylesheet-manager.ts`: fixed `adoptStyleSheets` to use `sheet.cssRules` with a `SecurityError`-only catch (was using the deprecated `sheet.rules` and swallowing all errors).

### Types (`packages/types/src/index.ts`)
- Added `serializedAdoptedStyleSheet` type and `adoptedStyleSheets?` field to `elementNode` and `documentNode`.

### Replayer (`packages/rrweb/src/replay/index.ts`)
- Added `applySnapshotAdoptedStyleSheets()`: creates `CSSStyleSheet` objects in the correct window context, registers them in `styleMirror` with the stored styleIds, inserts rules, and assigns them to the shadow root or document.
- **Post-order backfill**: `afterAppend` fires bottom-up, so a deeply nested shadow host's empty de-dup entry can fire *before* the ancestor's full-rules entry. When the ancestor's entry arrives and finds an existing sheet, the rules are back-filled onto the shared `CSSStyleSheet` instance so both shadow roots end up correctly styled.
- **Virtual DOM seek fix**: when `attachDocumentToIframe` fires while `usingVirtualDom=true`, real nodes don't exist yet. Inline `adoptedStyleSheets` are queued in `snapshotAdoptedStyleSheetQueue` and applied in the Flush handler after `diff()` materializes nodes — mirroring the existing `constructedStyleMutations`/`adoptedStyleSheets` deferral pattern.

## Result

The full snapshot is now self-contained for adopted stylesheet CSS. Dropped incremental `AdoptedStyleSheet` events no longer result in broken styles. A shared `CSSStyleSheet` adopted by multiple shadow roots is replayed as a single shared instance (same object identity), matching the original page behavior.

## Review & testing

This PR went through **10 rounds of automated Opus code review** (Claude Code reviewer subagent), with each round's comments addressed before the next round was run. The final round found no blocking issues.

Test coverage added:
- **Unit tests** (Vitest + Puppeteer): 3 new replayer tests covering (1) inline adoptedStyleSheets applied on full snapshot, (2) two sibling shadow roots sharing the same `CSSStyleSheet` object, and (3) nested shadow hosts where the inner host's `afterAppend` fires before the outer's (post-order backfill). 1 new record test for `captureAdoptedStyleSheets: false`.
- **Full test suites passing**: `record.test.ts` (27 tests), `replayer.test.ts` (41 tests), `rrweb-snapshot` (124 tests).

## Test plan

- [x] Shadow DOM styles correctly applied on replay for pages using `adoptedStyleSheets`
- [x] Two sibling shadow roots sharing a `styleId` replayed with the same `CSSStyleSheet` object (identity check)
- [x] Nested shadow hosts: inner host's `afterAppend` fires before outer's (post-order) — rules correctly back-filled
- [x] `captureAdoptedStyleSheets: false` — snapshot no longer inlines rules; incremental events still carry them
- [x] Replay still works when incremental `AdoptedStyleSheet` events arrive normally (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)