### PR TITLE
Version Packages (alpha)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -61,6 +61,7 @@
     "happy-eagles-bow",
     "hip-worms-relax",
     "hungry-dodos-taste",
+    "inline-adopted-stylesheets",
     "inlineImage-maybeNot-crossOrigin",
     "kind-kids-design",
     "kind-queens-breathe",

--- a/packages/all/CHANGELOG.md
+++ b/packages/all/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @amplitude/rrweb-all
 
+## 2.0.0-alpha.40
+
+### Patch Changes
+
+- Updated dependencies [[`f66e0ab`](https://github.com/amplitude/rrweb/commit/f66e0ab409a391112e9204f32bd1977db72207da)]:
+  - @amplitude/rrweb@2.0.0-alpha.40
+  - @amplitude/rrweb-types@2.0.0-alpha.40
+  - @amplitude/rrweb-packer@2.0.0-alpha.40
+
 ## 2.0.0-alpha.39
 
 ### Patch Changes

--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/rrweb-all",
-  "version": "2.0.0-alpha.39",
+  "version": "2.0.0-alpha.40",
   "publishConfig": {
     "access": "public"
   },
@@ -56,9 +56,9 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@amplitude/rrweb-types": "^2.0.0-alpha.39",
-    "@amplitude/rrweb-packer": "^2.0.0-alpha.39",
-    "@amplitude/rrweb": "^2.0.0-alpha.39"
+    "@amplitude/rrweb-types": "^2.0.0-alpha.40",
+    "@amplitude/rrweb-packer": "^2.0.0-alpha.40",
+    "@amplitude/rrweb": "^2.0.0-alpha.40"
   },
   "browserslist": [
     "supports es6-class"

--- a/packages/packer/CHANGELOG.md
+++ b/packages/packer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @amplitude/rrweb-packer
 
+## 2.0.0-alpha.40
+
+### Patch Changes
+
+- Updated dependencies [[`f66e0ab`](https://github.com/amplitude/rrweb/commit/f66e0ab409a391112e9204f32bd1977db72207da)]:
+  - @amplitude/rrweb-types@2.0.0-alpha.40
+
 ## 2.0.0-alpha.39
 
 ### Patch Changes

--- a/packages/packer/package.json
+++ b/packages/packer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/rrweb-packer",
-  "version": "2.0.0-alpha.39",
+  "version": "2.0.0-alpha.40",
   "publishConfig": {
     "access": "public"
   },
@@ -78,7 +78,7 @@
   },
   "dependencies": {
     "fflate": "^0.4.4",
-    "@amplitude/rrweb-types": "^2.0.0-alpha.39"
+    "@amplitude/rrweb-types": "^2.0.0-alpha.40"
   },
   "browserslist": [
     "supports es6-class"

--- a/packages/plugins/rrweb-plugin-canvas-webrtc-record/CHANGELOG.md
+++ b/packages/plugins/rrweb-plugin-canvas-webrtc-record/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @amplitude/rrweb-plugin-canvas-webrtc-record
 
+## 2.0.0-alpha.40
+
+### Patch Changes
+
+- Updated dependencies [[`f66e0ab`](https://github.com/amplitude/rrweb/commit/f66e0ab409a391112e9204f32bd1977db72207da)]:
+  - @amplitude/rrweb@2.0.0-alpha.40
+
 ## 2.0.0-alpha.39
 
 ### Patch Changes

--- a/packages/plugins/rrweb-plugin-canvas-webrtc-record/package.json
+++ b/packages/plugins/rrweb-plugin-canvas-webrtc-record/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/rrweb-plugin-canvas-webrtc-record",
-  "version": "2.0.0-alpha.39",
+  "version": "2.0.0-alpha.40",
   "description": "",
   "type": "module",
   "main": "./dist/rrweb-plugin-canvas-webrtc-record.umd.cjs",
@@ -43,12 +43,12 @@
   },
   "homepage": "https://github.com/rrweb-io/rrweb#readme",
   "devDependencies": {
-    "@amplitude/rrweb": "^2.0.0-alpha.39",
+    "@amplitude/rrweb": "^2.0.0-alpha.40",
     "typescript": "^5.4.5",
     "vite": "^6",
     "vite-plugin-dts": "^3.9.1"
   },
   "peerDependencies": {
-    "@amplitude/rrweb": "^2.0.0-alpha.39"
+    "@amplitude/rrweb": "^2.0.0-alpha.40"
   }
 }

--- a/packages/plugins/rrweb-plugin-canvas-webrtc-replay/CHANGELOG.md
+++ b/packages/plugins/rrweb-plugin-canvas-webrtc-replay/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @amplitude/rrweb-plugin-canvas-webrtc-replay
 
+## 2.0.0-alpha.40
+
+### Patch Changes
+
+- Updated dependencies [[`f66e0ab`](https://github.com/amplitude/rrweb/commit/f66e0ab409a391112e9204f32bd1977db72207da)]:
+  - @amplitude/rrweb@2.0.0-alpha.40
+
 ## 2.0.0-alpha.39
 
 ### Patch Changes

--- a/packages/plugins/rrweb-plugin-canvas-webrtc-replay/package.json
+++ b/packages/plugins/rrweb-plugin-canvas-webrtc-replay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/rrweb-plugin-canvas-webrtc-replay",
-  "version": "2.0.0-alpha.39",
+  "version": "2.0.0-alpha.40",
   "description": "",
   "type": "module",
   "main": "./dist/rrweb-plugin-canvas-webrtc-replay.umd.cjs",
@@ -43,12 +43,12 @@
   },
   "homepage": "https://github.com/rrweb-io/rrweb#readme",
   "devDependencies": {
-    "@amplitude/rrweb": "^2.0.0-alpha.39",
+    "@amplitude/rrweb": "^2.0.0-alpha.40",
     "typescript": "^5.4.5",
     "vite": "^6",
     "vite-plugin-dts": "^3.9.1"
   },
   "peerDependencies": {
-    "@amplitude/rrweb": "^2.0.0-alpha.39"
+    "@amplitude/rrweb": "^2.0.0-alpha.40"
   }
 }

--- a/packages/plugins/rrweb-plugin-console-record/CHANGELOG.md
+++ b/packages/plugins/rrweb-plugin-console-record/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @amplitude/rrweb-plugin-console-record
 
+## 2.0.0-alpha.40
+
+### Patch Changes
+
+- Updated dependencies [[`f66e0ab`](https://github.com/amplitude/rrweb/commit/f66e0ab409a391112e9204f32bd1977db72207da)]:
+  - @amplitude/rrweb@2.0.0-alpha.40
+
 ## 2.0.0-alpha.39
 
 ### Patch Changes

--- a/packages/plugins/rrweb-plugin-console-record/package.json
+++ b/packages/plugins/rrweb-plugin-console-record/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/rrweb-plugin-console-record",
-  "version": "2.0.0-alpha.39",
+  "version": "2.0.0-alpha.40",
   "description": "",
   "type": "module",
   "main": "./dist/rrweb-plugin-console-record.umd.cjs",
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/rrweb-io/rrweb#readme",
   "devDependencies": {
-    "@amplitude/rrweb": "^2.0.0-alpha.39",
+    "@amplitude/rrweb": "^2.0.0-alpha.40",
     "typescript": "^5.4.5",
     "vite": "^6",
     "vite-plugin-dts": "^3.9.1",
@@ -53,6 +53,6 @@
     "puppeteer": "^20.9.0"
   },
   "peerDependencies": {
-    "@amplitude/rrweb": "^2.0.0-alpha.39"
+    "@amplitude/rrweb": "^2.0.0-alpha.40"
   }
 }

--- a/packages/plugins/rrweb-plugin-console-replay/CHANGELOG.md
+++ b/packages/plugins/rrweb-plugin-console-replay/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @amplitude/rrweb-plugin-console-replay
 
+## 2.0.0-alpha.40
+
+### Patch Changes
+
+- Updated dependencies [[`f66e0ab`](https://github.com/amplitude/rrweb/commit/f66e0ab409a391112e9204f32bd1977db72207da)]:
+  - @amplitude/rrweb@2.0.0-alpha.40
+
 ## 2.0.0-alpha.39
 
 ### Patch Changes

--- a/packages/plugins/rrweb-plugin-console-replay/package.json
+++ b/packages/plugins/rrweb-plugin-console-replay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/rrweb-plugin-console-replay",
-  "version": "2.0.0-alpha.39",
+  "version": "2.0.0-alpha.40",
   "description": "",
   "type": "module",
   "main": "./dist/rrweb-plugin-console-replay.umd.cjs",
@@ -43,13 +43,13 @@
   },
   "homepage": "https://github.com/rrweb-io/rrweb#readme",
   "devDependencies": {
-    "@amplitude/rrweb-plugin-console-record": "^2.0.0-alpha.39",
-    "@amplitude/rrweb": "^2.0.0-alpha.39",
+    "@amplitude/rrweb-plugin-console-record": "^2.0.0-alpha.40",
+    "@amplitude/rrweb": "^2.0.0-alpha.40",
     "typescript": "^5.4.5",
     "vite": "^6",
     "vite-plugin-dts": "^3.9.1"
   },
   "peerDependencies": {
-    "@amplitude/rrweb": "^2.0.0-alpha.39"
+    "@amplitude/rrweb": "^2.0.0-alpha.40"
   }
 }

--- a/packages/plugins/rrweb-plugin-sequential-id-record/CHANGELOG.md
+++ b/packages/plugins/rrweb-plugin-sequential-id-record/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @amplitude/rrweb-plugin-sequential-id-record
 
+## 2.0.0-alpha.40
+
+### Patch Changes
+
+- Updated dependencies [[`f66e0ab`](https://github.com/amplitude/rrweb/commit/f66e0ab409a391112e9204f32bd1977db72207da)]:
+  - @amplitude/rrweb@2.0.0-alpha.40
+
 ## 2.0.0-alpha.39
 
 ### Patch Changes

--- a/packages/plugins/rrweb-plugin-sequential-id-record/package.json
+++ b/packages/plugins/rrweb-plugin-sequential-id-record/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/rrweb-plugin-sequential-id-record",
-  "version": "2.0.0-alpha.39",
+  "version": "2.0.0-alpha.40",
   "description": "",
   "type": "module",
   "main": "./dist/rrweb-plugin-sequential-id-record.umd.cjs",
@@ -43,12 +43,12 @@
   },
   "homepage": "https://github.com/rrweb-io/rrweb#readme",
   "devDependencies": {
-    "@amplitude/rrweb": "^2.0.0-alpha.39",
+    "@amplitude/rrweb": "^2.0.0-alpha.40",
     "typescript": "^5.4.5",
     "vite": "^6",
     "vite-plugin-dts": "^3.9.1"
   },
   "peerDependencies": {
-    "@amplitude/rrweb": "^2.0.0-alpha.39"
+    "@amplitude/rrweb": "^2.0.0-alpha.40"
   }
 }

--- a/packages/plugins/rrweb-plugin-sequential-id-replay/CHANGELOG.md
+++ b/packages/plugins/rrweb-plugin-sequential-id-replay/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @amplitude/rrweb-plugin-sequential-id-replay
 
+## 2.0.0-alpha.40
+
+### Patch Changes
+
+- Updated dependencies [[`f66e0ab`](https://github.com/amplitude/rrweb/commit/f66e0ab409a391112e9204f32bd1977db72207da)]:
+  - @amplitude/rrweb@2.0.0-alpha.40
+
 ## 2.0.0-alpha.39
 
 ### Patch Changes

--- a/packages/plugins/rrweb-plugin-sequential-id-replay/package.json
+++ b/packages/plugins/rrweb-plugin-sequential-id-replay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/rrweb-plugin-sequential-id-replay",
-  "version": "2.0.0-alpha.39",
+  "version": "2.0.0-alpha.40",
   "description": "",
   "type": "module",
   "main": "./dist/rrweb-plugin-sequential-id-replay.umd.cjs",
@@ -43,13 +43,13 @@
   },
   "homepage": "https://github.com/rrweb-io/rrweb#readme",
   "devDependencies": {
-    "@amplitude/rrweb-plugin-sequential-id-record": "^2.0.0-alpha.39",
-    "@amplitude/rrweb": "^2.0.0-alpha.39",
+    "@amplitude/rrweb-plugin-sequential-id-record": "^2.0.0-alpha.40",
+    "@amplitude/rrweb": "^2.0.0-alpha.40",
     "typescript": "^5.4.5",
     "vite": "^6",
     "vite-plugin-dts": "^3.9.1"
   },
   "peerDependencies": {
-    "@amplitude/rrweb": "^2.0.0-alpha.39"
+    "@amplitude/rrweb": "^2.0.0-alpha.40"
   }
 }

--- a/packages/record/CHANGELOG.md
+++ b/packages/record/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @amplitude/rrweb-record
 
+## 2.0.0-alpha.40
+
+### Patch Changes
+
+- Updated dependencies [[`f66e0ab`](https://github.com/amplitude/rrweb/commit/f66e0ab409a391112e9204f32bd1977db72207da)]:
+  - @amplitude/rrweb@2.0.0-alpha.40
+  - @amplitude/rrweb-types@2.0.0-alpha.40
+
 ## 2.0.0-alpha.39
 
 ### Patch Changes

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/rrweb-record",
-  "version": "2.0.0-alpha.39",
+  "version": "2.0.0-alpha.40",
   "publishConfig": {
     "access": "public"
   },
@@ -55,8 +55,8 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@amplitude/rrweb-types": "^2.0.0-alpha.39",
-    "@amplitude/rrweb": "^2.0.0-alpha.39"
+    "@amplitude/rrweb-types": "^2.0.0-alpha.40",
+    "@amplitude/rrweb": "^2.0.0-alpha.40"
   },
   "browserslist": [
     "supports es6-class"

--- a/packages/replay/CHANGELOG.md
+++ b/packages/replay/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @amplitude/rrweb-replay
 
+## 2.0.0-alpha.40
+
+### Patch Changes
+
+- Updated dependencies [[`f66e0ab`](https://github.com/amplitude/rrweb/commit/f66e0ab409a391112e9204f32bd1977db72207da)]:
+  - @amplitude/rrweb@2.0.0-alpha.40
+  - @amplitude/rrweb-types@2.0.0-alpha.40
+
 ## 2.0.0-alpha.39
 
 ### Patch Changes

--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/rrweb-replay",
-  "version": "2.0.0-alpha.39",
+  "version": "2.0.0-alpha.40",
   "publishConfig": {
     "access": "public"
   },
@@ -56,8 +56,8 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@amplitude/rrweb-types": "^2.0.0-alpha.39",
-    "@amplitude/rrweb": "^2.0.0-alpha.39"
+    "@amplitude/rrweb-types": "^2.0.0-alpha.40",
+    "@amplitude/rrweb": "^2.0.0-alpha.40"
   },
   "browserslist": [
     "supports es6-class"

--- a/packages/rrdom-nodejs/CHANGELOG.md
+++ b/packages/rrdom-nodejs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # rrdom-nodejs
 
+## 2.0.0-alpha.40
+
+### Patch Changes
+
+- Updated dependencies [[`f66e0ab`](https://github.com/amplitude/rrweb/commit/f66e0ab409a391112e9204f32bd1977db72207da)]:
+  - @amplitude/rrweb-types@2.0.0-alpha.40
+  - @amplitude/rrdom@2.0.0-alpha.40
+
 ## 2.0.0-alpha.39
 
 ### Patch Changes

--- a/packages/rrdom-nodejs/package.json
+++ b/packages/rrdom-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/rrdom-nodejs",
-  "version": "2.0.0-alpha.39",
+  "version": "2.0.0-alpha.40",
   "scripts": {
     "dev": "vite build --watch",
     "build": "yarn turbo run prepublish",
@@ -59,7 +59,7 @@
     "cssom": "^0.5.0",
     "cssstyle": "^2.3.0",
     "nwsapi": "2.2.0",
-    "@amplitude/rrdom": "^2.0.0-alpha.39",
-    "@amplitude/rrweb-types": "^2.0.0-alpha.39"
+    "@amplitude/rrdom": "^2.0.0-alpha.40",
+    "@amplitude/rrweb-types": "^2.0.0-alpha.40"
   }
 }

--- a/packages/rrdom/CHANGELOG.md
+++ b/packages/rrdom/CHANGELOG.md
@@ -1,5 +1,12 @@
 # rrdom
 
+## 2.0.0-alpha.40
+
+### Patch Changes
+
+- Updated dependencies [[`f66e0ab`](https://github.com/amplitude/rrweb/commit/f66e0ab409a391112e9204f32bd1977db72207da)]:
+  - @amplitude/rrweb-snapshot@2.0.0-alpha.40
+
 ## 2.0.0-alpha.39
 
 ### Patch Changes

--- a/packages/rrdom/package.json
+++ b/packages/rrdom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/rrdom",
-  "version": "2.0.0-alpha.39",
+  "version": "2.0.0-alpha.40",
   "homepage": "https://github.com/rrweb-io/rrweb/tree/main/packages/rrdom#readme",
   "license": "MIT",
   "type": "module",
@@ -41,7 +41,7 @@
     "url": "https://github.com/rrweb-io/rrweb/issues"
   },
   "devDependencies": {
-    "@amplitude/rrweb-types": "^2.0.0-alpha.39",
+    "@amplitude/rrweb-types": "^2.0.0-alpha.40",
     "@types/puppeteer": "^5.4.4",
     "@typescript-eslint/eslint-plugin": "^5.23.0",
     "@typescript-eslint/parser": "^5.23.0",
@@ -52,6 +52,6 @@
     "vite-plugin-dts": "^3.9.1"
   },
   "dependencies": {
-    "@amplitude/rrweb-snapshot": "^2.0.0-alpha.39"
+    "@amplitude/rrweb-snapshot": "^2.0.0-alpha.40"
   }
 }

--- a/packages/rrvideo/CHANGELOG.md
+++ b/packages/rrvideo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # rrvideo
 
+## 2.0.0-alpha.40
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @amplitude/rrweb-player@2.0.0-alpha.40
+
 ## 2.0.0-alpha.39
 
 ### Patch Changes

--- a/packages/rrvideo/package.json
+++ b/packages/rrvideo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/rrvideo",
-  "version": "2.0.0-alpha.39",
+  "version": "2.0.0-alpha.40",
   "description": "transform rrweb session into video",
   "main": "build/index.js",
   "bin": {
@@ -25,7 +25,7 @@
     "url": "git+https://github.com/amplitude/rrweb.git"
   },
   "devDependencies": {
-    "@amplitude/rrweb": "^2.0.0-alpha.39",
+    "@amplitude/rrweb": "^2.0.0-alpha.40",
     "@types/fs-extra": "11.0.1",
     "@types/jest": "^27.4.1",
     "@types/minimist": "^1.2.1",
@@ -34,7 +34,7 @@
     "ts-jest": "^27.1.3"
   },
   "dependencies": {
-    "@amplitude/rrweb-player": "^2.0.0-alpha.39",
+    "@amplitude/rrweb-player": "^2.0.0-alpha.40",
     "@open-tech-world/cli-progress-bar": "^2.0.2",
     "fs-extra": "^11.1.1",
     "minimist": "^1.2.5",

--- a/packages/rrweb-player/CHANGELOG.md
+++ b/packages/rrweb-player/CHANGELOG.md
@@ -1,5 +1,13 @@
 # rrweb-player
 
+## 2.0.0-alpha.40
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @amplitude/rrweb-replay@2.0.0-alpha.40
+  - @amplitude/rrweb-packer@2.0.0-alpha.40
+
 ## 2.0.0-alpha.39
 
 ### Patch Changes

--- a/packages/rrweb-player/package.json
+++ b/packages/rrweb-player/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@amplitude/rrweb-player",
-  "version": "2.0.0-alpha.39",
+  "version": "2.0.0-alpha.40",
   "devDependencies": {
-    "@amplitude/rrweb-types": "^2.0.0-alpha.39",
+    "@amplitude/rrweb-types": "^2.0.0-alpha.40",
     "@sveltejs/vite-plugin-svelte": "^6.2.1",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
@@ -15,8 +15,8 @@
   },
   "dependencies": {
     "@tsconfig/svelte": "^1.0.0",
-    "@amplitude/rrweb-replay": "^2.0.0-alpha.39",
-    "@amplitude/rrweb-packer": "^2.0.0-alpha.39"
+    "@amplitude/rrweb-replay": "^2.0.0-alpha.40",
+    "@amplitude/rrweb-packer": "^2.0.0-alpha.40"
   },
   "scripts": {
     "dev": "vite build --watch",

--- a/packages/rrweb-snapshot/CHANGELOG.md
+++ b/packages/rrweb-snapshot/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rrweb-snapshot
 
+## 2.0.0-alpha.40
+
+### Patch Changes
+
+- [#101](https://github.com/amplitude/rrweb/pull/101) [`f66e0ab`](https://github.com/amplitude/rrweb/commit/f66e0ab409a391112e9204f32bd1977db72207da) Thanks [@lewgordon-amplitude](https://github.com/lewgordon-amplitude)! - Fix adoptedStyleSheets CSS not applied on replay when incremental AdoptedStyleSheet events are dropped in transit. CSS rules are now serialized inline in the full snapshot so replay is self-contained. Adds a `captureAdoptedStyleSheets` record option (default `true`) to opt out if snapshot size is a concern.
+
 ## 2.0.0-alpha.39
 
 ## 2.0.0-alpha.38

--- a/packages/rrweb-snapshot/package.json
+++ b/packages/rrweb-snapshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/rrweb-snapshot",
-  "version": "2.0.0-alpha.39",
+  "version": "2.0.0-alpha.40",
   "description": "rrweb's component to take a snapshot of DOM, aka DOM serializer",
   "scripts": {
     "prepare": "npm run prepack",
@@ -54,8 +54,8 @@
   },
   "homepage": "https://github.com/amplitude/rrweb/tree/master/packages/rrweb-snapshot#readme",
   "devDependencies": {
-    "@amplitude/rrweb-types": "^2.0.0-alpha.39",
-    "@amplitude/rrweb-utils": "^2.0.0-alpha.39",
+    "@amplitude/rrweb-types": "^2.0.0-alpha.40",
+    "@amplitude/rrweb-utils": "^2.0.0-alpha.40",
     "@types/jsdom": "^20.0.0",
     "@types/node": "^18.15.11",
     "@types/puppeteer": "^5.4.4",

--- a/packages/rrweb/CHANGELOG.md
+++ b/packages/rrweb/CHANGELOG.md
@@ -1,5 +1,19 @@
 # rrweb
 
+## 2.0.0-alpha.40
+
+### Minor Changes
+
+- [#101](https://github.com/amplitude/rrweb/pull/101) [`f66e0ab`](https://github.com/amplitude/rrweb/commit/f66e0ab409a391112e9204f32bd1977db72207da) Thanks [@lewgordon-amplitude](https://github.com/lewgordon-amplitude)! - Fix adoptedStyleSheets CSS not applied on replay when incremental AdoptedStyleSheet events are dropped in transit. CSS rules are now serialized inline in the full snapshot so replay is self-contained. Adds a `captureAdoptedStyleSheets` record option (default `true`) to opt out if snapshot size is a concern.
+
+### Patch Changes
+
+- Updated dependencies [[`f66e0ab`](https://github.com/amplitude/rrweb/commit/f66e0ab409a391112e9204f32bd1977db72207da)]:
+  - @amplitude/rrweb-snapshot@2.0.0-alpha.40
+  - @amplitude/rrweb-types@2.0.0-alpha.40
+  - @amplitude/rrdom@2.0.0-alpha.40
+  - @amplitude/rrweb-utils@2.0.0-alpha.40
+
 ## 2.0.0-alpha.39
 
 ### Patch Changes

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/rrweb",
-  "version": "2.0.0-alpha.39",
+  "version": "2.0.0-alpha.40",
   "description": "record and replay the web",
   "scripts": {
     "prepare": "npm run prepack",
@@ -81,10 +81,10 @@
     "vite-plugin-dts": "^3.9.1"
   },
   "dependencies": {
-    "@amplitude/rrdom": "^2.0.0-alpha.39",
-    "@amplitude/rrweb-types": "^2.0.0-alpha.39",
-    "@amplitude/rrweb-snapshot": "^2.0.0-alpha.39",
-    "@amplitude/rrweb-utils": "^2.0.0-alpha.39",
+    "@amplitude/rrdom": "^2.0.0-alpha.40",
+    "@amplitude/rrweb-types": "^2.0.0-alpha.40",
+    "@amplitude/rrweb-snapshot": "^2.0.0-alpha.40",
+    "@amplitude/rrweb-utils": "^2.0.0-alpha.40",
     "@types/css-font-loading-module": "0.0.7",
     "@xstate/fsm": "^1.4.0",
     "base64-arraybuffer": "^1.0.1",

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rrweb/types
 
+## 2.0.0-alpha.40
+
+### Patch Changes
+
+- [#101](https://github.com/amplitude/rrweb/pull/101) [`f66e0ab`](https://github.com/amplitude/rrweb/commit/f66e0ab409a391112e9204f32bd1977db72207da) Thanks [@lewgordon-amplitude](https://github.com/lewgordon-amplitude)! - Fix adoptedStyleSheets CSS not applied on replay when incremental AdoptedStyleSheet events are dropped in transit. CSS rules are now serialized inline in the full snapshot so replay is self-contained. Adds a `captureAdoptedStyleSheets` record option (default `true`) to opt out if snapshot size is a concern.
+
 ## 2.0.0-alpha.39
 
 ## 2.0.0-alpha.38

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/rrweb-types",
-  "version": "2.0.0-alpha.39",
+  "version": "2.0.0-alpha.40",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @amplitude/rrweb-utils
 
+## 2.0.0-alpha.40
+
 ## 2.0.0-alpha.39
 
 ## 2.0.0-alpha.38

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/rrweb-utils",
-  "version": "2.0.0-alpha.39",
+  "version": "2.0.0-alpha.40",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/web-extension/CHANGELOG.md
+++ b/packages/web-extension/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @rrweb/web-extension
 
+## 2.0.0-alpha.40
+
+### Patch Changes
+
+- Updated dependencies [[`f66e0ab`](https://github.com/amplitude/rrweb/commit/f66e0ab409a391112e9204f32bd1977db72207da)]:
+  - @amplitude/rrweb@2.0.0-alpha.40
+  - @amplitude/rrweb-player@2.0.0-alpha.40
+
 ## 2.0.0-alpha.39
 
 ### Patch Changes

--- a/packages/web-extension/package.json
+++ b/packages/web-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amplitude/rrweb-web-extension",
   "private": true,
-  "version": "2.0.0-alpha.39",
+  "version": "2.0.0-alpha.40",
   "description": "The web extension of rrweb which helps to run rrweb on any website out of box",
   "author": "Amplitude Inc",
   "license": "MIT",
@@ -18,7 +18,7 @@
     "prepublish": "yarn build"
   },
   "devDependencies": {
-    "@amplitude/rrweb-types": "^2.0.0-alpha.39",
+    "@amplitude/rrweb-types": "^2.0.0-alpha.40",
     "@types/react-dom": "^18.0.6",
     "@types/webextension-polyfill": "^0.9.1",
     "@vitejs/plugin-react": "^4.2.1",
@@ -29,8 +29,8 @@
     "webextension-polyfill": "^0.10.0"
   },
   "dependencies": {
-    "@amplitude/rrweb": "^2.0.0-alpha.39",
-    "@amplitude/rrweb-player": "^2.0.0-alpha.39",
+    "@amplitude/rrweb": "^2.0.0-alpha.40",
+    "@amplitude/rrweb-player": "^2.0.0-alpha.40",
     "@chakra-ui/react": "^2.3.4",
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",


### PR DESCRIPTION
Bumps `@amplitude/rrweb` to `2.0.0-alpha.40` (minor), `@amplitude/rrweb-snapshot` and `@amplitude/rrweb-types` to `2.0.0-alpha.40` (patch).

This release contains the fix from #101: adopted stylesheet CSS rules are now serialized inline in the full snapshot, preventing missing styles when incremental `AdoptedStyleSheet` events are dropped in transit.

Created manually because the GitHub Actions Release workflow lacks permission to create PRs ([failed run](https://github.com/amplitude/rrweb/actions/runs/24795778748)).