### PR TITLE
fix(replay): preserve shadow-DOM adoptedStyleSheets across seek-cache restores (SR-4260)

### DIFF
--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -983,13 +983,21 @@ export class Replayer {
       if (meta) scratchMirror.add(node, meta);
     });
 
-    // onAdoptedStyleSheet is intentionally omitted: seek-cache snapshots capture
-    // static DOM structure only. AdoptedStyleSheets are re-applied when the
-    // replayer replays incremental events from the seek checkpoint to the target time.
+    // Capture adoptedStyleSheets state so the cache restore reproduces shadow-DOM
+    // styling. Without this, hosts that adopted sheets before the cache anchor
+    // (the common Web Component pattern: adopt once at construction) lose their
+    // sheets on cache-hit seek — the replayer skips events ≤ the checkpoint, so
+    // the original adoption events are never replayed.
+    //
+    // The callback returns the player-side styleId already tracked by styleMirror
+    // (which uses recording-side ids), so a cache restore creates new CSSStyleSheet
+    // instances under the same ids and any post-checkpoint incremental events
+    // referencing them resolve correctly.
     const snapshotNode = snapshot(this.iframe.contentDocument, {
       mirror: scratchMirror,
       blockClass: this.config.blockClass,
       inlineStylesheet: true,
+      onAdoptedStyleSheet: (sheet) => this.styleMirror.add(sheet),
     });
     if (!snapshotNode) return;
 

--- a/packages/rrweb/test/events/adopted-style-sheet-shared-with-incrementals.ts
+++ b/packages/rrweb/test/events/adopted-style-sheet-shared-with-incrementals.ts
@@ -1,0 +1,122 @@
+import type { eventWithTime } from '@amplitude/rrweb-types';
+import { EventType, IncrementalSource } from '@amplitude/rrweb-types';
+
+/**
+ * Two shadow hosts share a CSSStyleSheet (styleId 1) declared in the
+ * FullSnapshot, followed by harmless incremental events spread over a few
+ * seconds. The incremental events exist so the seek cache has a window to
+ * capture a checkpoint after the FullSnapshot — no further AdoptedStyleSheet
+ * events are emitted, so a cache-restored seek must reproduce the shared-sheet
+ * adoption from the cached snapshot alone (it cannot rely on incremental
+ * adoption events to repaint styling after a checkpoint hit).
+ */
+const now = Date.now();
+
+const events: eventWithTime[] = [
+  { type: EventType.DomContentLoaded, data: {}, timestamp: now },
+  {
+    type: EventType.Meta,
+    data: { href: 'about:blank', width: 1920, height: 1080 },
+    timestamp: now + 100,
+  },
+  {
+    type: EventType.FullSnapshot,
+    data: {
+      node: {
+        type: 0,
+        childNodes: [
+          { type: 1, name: 'html', publicId: '', systemId: '', id: 2 },
+          {
+            type: 2,
+            tagName: 'html',
+            attributes: {},
+            childNodes: [
+              {
+                type: 2,
+                tagName: 'head',
+                attributes: {},
+                childNodes: [],
+                id: 4,
+              },
+              {
+                type: 2,
+                tagName: 'body',
+                attributes: {},
+                childNodes: [
+                  { type: 3, textContent: '\n  ', id: 6 },
+                  {
+                    type: 2,
+                    tagName: 'div',
+                    attributes: { id: 'shadow-host-1' },
+                    childNodes: [
+                      {
+                        type: 2,
+                        tagName: 'span',
+                        attributes: {},
+                        childNodes: [
+                          { type: 3, textContent: 'text in shadow 1', id: 9 },
+                        ],
+                        id: 8,
+                        isShadow: true,
+                      },
+                    ],
+                    id: 7,
+                    isShadowHost: true,
+                    adoptedStyleSheets: [
+                      {
+                        styleId: 1,
+                        rules: [{ rule: 'span { color: red; }', index: 0 }],
+                      },
+                    ],
+                  },
+                  { type: 3, textContent: '\n  ', id: 10 },
+                  {
+                    type: 2,
+                    tagName: 'div',
+                    attributes: { id: 'shadow-host-2' },
+                    childNodes: [
+                      {
+                        type: 2,
+                        tagName: 'span',
+                        attributes: {},
+                        childNodes: [
+                          { type: 3, textContent: 'text in shadow 2', id: 13 },
+                        ],
+                        id: 12,
+                        isShadow: true,
+                      },
+                    ],
+                    id: 11,
+                    isShadowHost: true,
+                    adoptedStyleSheets: [{ styleId: 1, rules: [] }],
+                  },
+                  { type: 3, textContent: '\n', id: 14 },
+                ],
+                id: 5,
+              },
+            ],
+            id: 3,
+          },
+        ],
+        id: 1,
+      },
+      initialOffset: { left: 0, top: 0 },
+    },
+    timestamp: now + 100,
+  },
+  // Mouse moves spaced 500ms apart give the seek cache distinct anchor points
+  // without touching shadow DOM state.
+  ...(Array.from({ length: 8 }, (_, i) => ({
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MouseInteraction,
+      type: 1,
+      id: 1,
+      x: i * 5,
+      y: i * 5,
+    },
+    timestamp: now + 500 + i * 500,
+  })) as eventWithTime[]),
+];
+
+export default events;

--- a/packages/rrweb/test/replayer.test.ts
+++ b/packages/rrweb/test/replayer.test.ts
@@ -7,6 +7,7 @@ import { vi } from 'vitest';
 import adoptedStyleSheet from './events/adopted-style-sheet';
 import adoptedStyleSheetInSnapshot from './events/adopted-style-sheet-in-snapshot';
 import adoptedStyleSheetSharedInSnapshot from './events/adopted-style-sheet-shared-in-snapshot';
+import adoptedStyleSheetSharedWithIncrementals from './events/adopted-style-sheet-shared-with-incrementals';
 import adoptedStyleSheetNestedSharedInSnapshot from './events/adopted-style-sheet-nested-shared-in-snapshot';
 import adoptedStyleSheetModification from './events/adopted-style-sheet-modification';
 import canvasInIframe from './events/canvas-in-iframe';
@@ -1183,6 +1184,88 @@ describe('replayer', function () {
           innerHost.shadowRoot!.adoptedStyleSheets[0]
         );
       }),
+    ).toBe(true);
+  });
+
+  it('preserves shadow-DOM adoptedStyleSheets across a seek-cache restore (SR-4260)', async () => {
+    // Regression: the seek cache used to omit onAdoptedStyleSheet when
+    // serializing the cached snapshot, so restoring from a checkpoint dropped
+    // every shadow host's adoptedStyleSheets and styling vanished after a
+    // scrub. The cache-hit path is reached on a backward seek to a time at or
+    // after a previously captured checkpoint, so we warm the cache at 2000ms,
+    // jump forward to 3500ms, then seek back to 2500ms — that final seek
+    // restores from the 2000ms cache entry rather than replaying from the
+    // original FullSnapshot, exercising exactly the path the bug lived on.
+    await page.evaluate(`
+      events = ${JSON.stringify(adoptedStyleSheetSharedWithIncrementals)};
+      const { Replayer } = rrweb;
+      var replayer = new Replayer(events, {
+        showDebug: true,
+        useSeekCache: true,
+      });
+      replayer.pause(2000);
+    `);
+    // Wait for captureSeekCacheEntry's 0-delay timer to fire and serialize.
+    await page.waitForTimeout(300);
+
+    await page.evaluate('replayer.pause(3500);');
+    await page.waitForTimeout(300);
+
+    // Backward seek — applyEventsSynchronously consults seekCache and the
+    // 2000ms entry wins (latest entry ≤ 2500ms target).
+    await page.evaluate('replayer.pause(2500);');
+    await page.waitForTimeout(300);
+
+    const iframe = await page.$('iframe');
+    const contentDocument = await iframe!.contentFrame()!;
+
+    // Both shadow hosts must have non-empty adoptedStyleSheets after restore.
+    expect(
+      await contentDocument!.evaluate(
+        () =>
+          document.querySelector('#shadow-host-1')!.shadowRoot!
+            .adoptedStyleSheets.length,
+      ),
+    ).toBe(1);
+    expect(
+      await contentDocument!.evaluate(
+        () =>
+          document.querySelector('#shadow-host-2')!.shadowRoot!
+            .adoptedStyleSheets.length,
+      ),
+    ).toBe(1);
+
+    // Computed styling must come through on both spans.
+    expect(
+      await contentDocument!.evaluate(
+        () =>
+          window.getComputedStyle(
+            document
+              .querySelector('#shadow-host-1')!
+              .shadowRoot!.querySelector('span')!,
+          ).color,
+      ),
+    ).toEqual('rgb(255, 0, 0)');
+    expect(
+      await contentDocument!.evaluate(
+        () =>
+          window.getComputedStyle(
+            document
+              .querySelector('#shadow-host-2')!
+              .shadowRoot!.querySelector('span')!,
+          ).color,
+      ),
+    ).toEqual('rgb(255, 0, 0)');
+
+    // Sheet must still be shared between hosts after restore.
+    expect(
+      await contentDocument!.evaluate(
+        () =>
+          document.querySelector('#shadow-host-1')!.shadowRoot!
+            .adoptedStyleSheets[0] ===
+          document.querySelector('#shadow-host-2')!.shadowRoot!
+            .adoptedStyleSheets[0],
+      ),
     ).toBe(true);
   });
 

--- a/packages/rrweb/test/replayer.test.ts
+++ b/packages/rrweb/test/replayer.test.ts
@@ -1187,7 +1187,7 @@ describe('replayer', function () {
     ).toBe(true);
   });
 
-  it('preserves shadow-DOM adoptedStyleSheets across a seek-cache restore (SR-4260)', async () => {
+  it('preserves shadow-DOM adoptedStyleSheets across a seek-cache restore', async () => {
     // Regression: the seek cache used to omit onAdoptedStyleSheet when
     // serializing the cached snapshot, so restoring from a checkpoint dropped
     // every shadow host's adoptedStyleSheets and styling vanished after a


### PR DESCRIPTION
## Summary

- Pass `onAdoptedStyleSheet` when serializing seek-cache snapshots so cached checkpoints encode each shadow host's adoption graph and the rules under each styleId.
- Add a regression test that warms the cache, jumps forward, and seeks back — exercising the cache-hit restore path that previously dropped adopted style sheets.

## Why

Follow-up from [SR-4254](https://linear.app/amplitude/issue/SR-4254) / #114417 (alpha.39 → alpha.40). The seek cache used to deliberately omit `onAdoptedStyleSheet`, betting that incremental adoption events between the checkpoint and the seek target would re-apply styling. That's false for the common Web Component pattern: chatbots and design-system components adopt their `CSSStyleSheet` once at element construction and never re-adopt. The original adoption events live before the cached checkpoint, the cache-hit path skips events ≤ checkpoint, and the cached snapshot itself carried no adopted-sheet info — so every cache-restored seek dropped shadow-DOM styling.

## What changed

`captureSeekCacheEntry` now passes `onAdoptedStyleSheet: (sheet) => this.styleMirror.add(sheet)` to `snapshot()`. The callback returns the player-side styleId already tracked by the styleMirror (which uses recording-side ids), so cache restoration via `applySnapshotAdoptedStyleSheets` reproduces the shared-sheet graph — including the `b713d0a1` back-fill path for nested-host post-order replay.

## Test plan

- [x] New test in `replayer.test.ts`: `preserves shadow-DOM adoptedStyleSheets across a seek-cache restore (SR-4260)` — pause(2000) → pause(3500) → pause(2500) (backward seek that hits the 2000ms cache entry); asserts both hosts have non-empty `adoptedStyleSheets`, same CSSStyleSheet object, and expected computed color.
- [x] Confirmed test fails on master without the fix (`adoptedStyleSheets.length = 0` after restore) and passes with it.
- [x] Full replayer.test.ts suite: 42/42 passing.
- [x] Full integration.test.ts suite: 50/50 passing.
- [x] seek-cache.test.ts unit + integration suites: 29/29 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)