### PR TITLE
fix(release): use deploy key for semantic-release push to protected master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Setup Node.js 24.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -46,3 +47,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'
+          GIT_AUTHOR_NAME: amplitude-sdk-bot
+          GIT_AUTHOR_EMAIL: amplitude-sdk-bot@users.noreply.github.com
+          GIT_COMMITTER_NAME: amplitude-sdk-bot
+          GIT_COMMITTER_EMAIL: amplitude-sdk-bot@users.noreply.github.com

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,10 @@ Prereleases ride a short-lived `alpha` branch that exists only while a prereleas
 
 Consumers install the latest prerelease with `npm install @amplitude/rrweb@alpha`.
 
+### Release infrastructure
+
+See [RELEASE.md](RELEASE.md) for the deploy-key + bypass-actor setup that lets semantic-release push the release commit back to a protected `master`, plus rotation and troubleshooting procedures.
+
 ## License
 
 rrweb is [MIT licensed](https://github.com/rrweb-io/rrweb/blob/master/LICENSE).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,85 @@
+# Release Infrastructure
+
+This repo's `Release` workflow (`.github/workflows/release.yml`) runs `semantic-release` on every push to `master` and `alpha`. semantic-release needs to push a `chore(release): X.Y.Z` commit (CHANGELOG + bumped `package.json` files) and a `vX.Y.Z` tag back to the branch — but `master` is protected by a [repository ruleset](https://github.com/amplitude/rrweb/rules) that requires changes to come through a PR.
+
+The default `GITHUB_TOKEN` provided to Actions authenticates as the `github-actions` integration, which is **not** covered by the ruleset's bypass actors. Direct pushes fail with `GH013: Changes must be made through a pull request`.
+
+The fix: a write-enabled **deploy key** is added as a `DeployKey` bypass actor on the ruleset. The Release workflow checks out the repo using the deploy key's SSH credentials (via `secrets.DEPLOY_KEY`), so pushes from the workflow are recognized as coming from the deploy key and bypass the rule.
+
+## What's in place
+
+| Resource | Where | Purpose |
+| --- | --- | --- |
+| `semantic-release deploy key` | Repo settings → Deploy keys | Write-enabled. Public half. |
+| `DEPLOY_KEY` Actions secret | Repo settings → Secrets and variables → Actions | Private half. Read by `actions/checkout` via `ssh-key:`. |
+| `DeployKey` bypass actor | Master ruleset → Bypass list | Lets pushes signed with the key skip the "PR required" rule. |
+| `amplitude-sdk-bot` git identity | `release.yml` env vars on the Release step | Author of the release commit. |
+
+## Rotation
+
+Rotate the deploy key periodically or any time the private key may have been exposed.
+
+```sh
+# 1. Generate a new ed25519 keypair (no passphrase; required for CI).
+KEYDIR=$(mktemp -d)
+ssh-keygen -t ed25519 -C "rrweb-semantic-release@amplitude" -f "$KEYDIR/key" -N "" -q
+
+# 2. Add the new public key as a deploy key (write enabled). Capture the new key id.
+NEW_KEY_ID=$(gh api repos/amplitude/rrweb/keys -X POST \
+  -f title='semantic-release deploy key' \
+  -f key="$(cat $KEYDIR/key.pub)" \
+  -F read_only=false --jq '.id')
+echo "New deploy key id: $NEW_KEY_ID"
+
+# 3. Replace the DEPLOY_KEY Actions secret with the new private key.
+gh secret set DEPLOY_KEY --repo amplitude/rrweb < "$KEYDIR/key"
+
+# 4. Securely delete the local private key. GitHub now holds both halves.
+shred -u "$KEYDIR/key" 2>/dev/null || rm -P "$KEYDIR/key"
+rm "$KEYDIR/key.pub" && rmdir "$KEYDIR"
+
+# 5. Delete the OLD deploy key from the repo (find its id in repo settings or via gh api repos/amplitude/rrweb/keys).
+gh api repos/amplitude/rrweb/keys/<OLD_KEY_ID> -X DELETE
+```
+
+The ruleset bypass actor is keyed on `DeployKey` (not a specific key id), so it automatically covers the new key — no ruleset update needed.
+
+## Initial bootstrap (from scratch)
+
+If this repo ever loses its release credentials (e.g., new fork), the full setup is:
+
+1. Run rotation steps 1–4 above to create the deploy key + secret.
+2. Add the deploy key as a `DeployKey` bypass actor on the master ruleset:
+   ```sh
+   gh api repos/amplitude/rrweb/rulesets/<RULESET_ID> -X PUT --input ruleset.json
+   ```
+   where `ruleset.json` contains the existing ruleset spec with one additional entry in `bypass_actors`:
+   ```json
+   {"actor_id": null, "actor_type": "DeployKey", "bypass_mode": "always"}
+   ```
+3. Confirm `.github/workflows/release.yml` references `secrets.DEPLOY_KEY` in the checkout step's `ssh-key:` and sets the `GIT_AUTHOR_*` / `GIT_COMMITTER_*` env vars on the Release step.
+
+## Troubleshooting
+
+### Release step fails with `GH013: Changes must be made through a pull request`
+
+The deploy key isn't bypassing the ruleset. Check, in order:
+1. `DEPLOY_KEY` secret exists on the repo (`gh secret list --repo amplitude/rrweb`).
+2. The checkout step in `release.yml` has `ssh-key: ${{ secrets.DEPLOY_KEY }}`.
+3. The master ruleset has a `DeployKey` bypass actor (`gh api repos/amplitude/rrweb/rulesets/<id>` → `bypass_actors`).
+4. The deploy key has write access (`read_only: false` in `gh api repos/amplitude/rrweb/keys`).
+
+### semantic-release says "no previous release, the next release version is 1.0.0"
+
+semantic-release couldn't find a `v*` git tag and is starting versioning from scratch. Verify with `git tag -l 'v*'` — if the expected tag is missing, create it pointing at the commit of the last published release and push:
+
+```sh
+git tag -a v<X.Y.Z> <COMMIT_SHA> -m "v<X.Y.Z>"
+git push origin v<X.Y.Z>
+```
+
+Re-run the Release workflow afterward.
+
+### Release commit pushed but no GitHub Release / npm publish
+
+Check the Release workflow logs for failures in the `@semantic-release/github` or `@semantic-release/exec` (publishCmd) plugin steps. The push and tag may have succeeded before a downstream plugin failed — the version commit / tag on `master` is the source of truth for what was attempted.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,12 +8,12 @@ The fix: a write-enabled **deploy key** is added as a `DeployKey` bypass actor o
 
 ## What's in place
 
-| Resource | Where | Purpose |
-| --- | --- | --- |
-| `semantic-release deploy key` | Repo settings → Deploy keys | Write-enabled. Public half. |
-| `DEPLOY_KEY` Actions secret | Repo settings → Secrets and variables → Actions | Private half. Read by `actions/checkout` via `ssh-key:`. |
-| `DeployKey` bypass actor | Master ruleset → Bypass list | Lets pushes signed with the key skip the "PR required" rule. |
-| `amplitude-sdk-bot` git identity | `release.yml` env vars on the Release step | Author of the release commit. |
+| Resource                         | Where                                           | Purpose                                                      |
+| -------------------------------- | ----------------------------------------------- | ------------------------------------------------------------ |
+| `semantic-release deploy key`    | Repo settings → Deploy keys                     | Write-enabled. Public half.                                  |
+| `DEPLOY_KEY` Actions secret      | Repo settings → Secrets and variables → Actions | Private half. Read by `actions/checkout` via `ssh-key:`.     |
+| `DeployKey` bypass actor         | Master ruleset → Bypass list                    | Lets pushes signed with the key skip the "PR required" rule. |
+| `amplitude-sdk-bot` git identity | `release.yml` env vars on the Release step      | Author of the release commit.                                |
 
 ## Rotation
 
@@ -55,7 +55,7 @@ If this repo ever loses its release credentials (e.g., new fork), the full setup
    ```
    where `ruleset.json` contains the existing ruleset spec with one additional entry in `bypass_actors`:
    ```json
-   {"actor_id": null, "actor_type": "DeployKey", "bypass_mode": "always"}
+   { "actor_id": null, "actor_type": "DeployKey", "bypass_mode": "always" }
    ```
 3. Confirm `.github/workflows/release.yml` references `secrets.DEPLOY_KEY` in the checkout step's `ssh-key:` and sets the `GIT_AUTHOR_*` / `GIT_COMMITTER_*` env vars on the Release step.
 
@@ -64,6 +64,7 @@ If this repo ever loses its release credentials (e.g., new fork), the full setup
 ### Release step fails with `GH013: Changes must be made through a pull request`
 
 The deploy key isn't bypassing the ruleset. Check, in order:
+
 1. `DEPLOY_KEY` secret exists on the repo (`gh secret list --repo amplitude/rrweb`).
 2. The checkout step in `release.yml` has `ssh-key: ${{ secrets.DEPLOY_KEY }}`.
 3. The master ruleset has a `DeployKey` bypass actor (`gh api repos/amplitude/rrweb/rulesets/<id>` → `bypass_actors`).


### PR DESCRIPTION
## Summary

Fixes the post-merge failure of semantic-release on PR #110: the release step pushed a `chore(release): X.Y.Z` commit + tag using the default `GITHUB_TOKEN`, which the master ruleset rejected with `GH013: Changes must be made through a pull request`. The `github-actions` integration that `GITHUB_TOKEN` authenticates as isn't covered by the ruleset's bypass actors, and individual users / GitHub Apps can't be added in a way that propagates to the workflow's token.

The fix follows the established Amplitude SDK convention (Android, iOS, Python, Flutter, RN) of using an SSH **deploy key** that's added as a bypass actor.

## What's already in place (out-of-band)

I've already created the credentials and bypass directly on the repo:

- **Deploy key** `semantic-release deploy key` (id `151174294`, write enabled) on `amplitude/rrweb`
- **Actions secret** `DEPLOY_KEY` holding the private half
- **`DeployKey` bypass actor** added to the master ruleset (id `4257881`)
- Pre-existing `v2.1.0` git tag created retroactively on `2b4e6938` so semantic-release recognizes 2.1.0 as the prior release (otherwise it defaults to 1.0.0)

## What this PR changes

- `.github/workflows/release.yml`:
  - `actions/checkout` now uses `ssh-key: ${{ secrets.DEPLOY_KEY }}` so the workspace remote is the SSH URL authenticated by the deploy key
  - Release step env adds `GIT_AUTHOR_NAME` / `GIT_AUTHOR_EMAIL` / `GIT_COMMITTER_NAME` / `GIT_COMMITTER_EMAIL` set to `amplitude-sdk-bot`
- New `RELEASE.md` covering: the why, what's in place, rotation procedure, initial bootstrap from scratch, and troubleshooting (the two failure modes we hit: `GH013` and "no previous release → 1.0.0")
- `CONTRIBUTING.md` Releases section gets a link to `RELEASE.md`

## Test plan

- [ ] CI green
- [ ] After merge, the Release workflow on the resulting `master` push succeeds:
  - `npx semantic-release` analyzes commits since `v2.1.0`
  - Computes next version (minor bump from `feat(release):` in #110 → `2.2.0`)
  - Pushes `chore(release): 2.2.0` commit + `v2.2.0` tag via the deploy key
  - Publishes packages to npm under `latest` dist-tag
  - Creates GitHub Release with auto-generated notes

Linear: SR-4223