### PR TITLE
fix(release): add NPM_TOKEN auth + skipVersion input for publish recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ on:
           - release
           - prerelease
           - dry-run
+      skipVersion:
+        type: boolean
+        description: 'Skip the lerna version step and only publish (recovery for a partial publish where the tag/commit already landed)'
+        required: false
+        default: false
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -87,13 +92,13 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=4096'
 
       - name: Version (release)
-        if: ${{ github.event.inputs.releaseType == 'release' }}
+        if: ${{ github.event.inputs.releaseType == 'release' && github.event.inputs.skipVersion != 'true' }}
         run: yarn release:version
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Version (prerelease)
-        if: ${{ github.event.inputs.releaseType == 'prerelease' }}
+        if: ${{ github.event.inputs.releaseType == 'prerelease' && github.event.inputs.skipVersion != 'true' }}
         run: yarn release:version:prerelease
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -107,9 +112,11 @@ jobs:
         run: yarn release:publish
         env:
           NPM_CONFIG_PROVENANCE: 'true'
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish (prerelease)
         if: ${{ github.event.inputs.releaseType == 'prerelease' }}
         run: yarn release:publish:prerelease
         env:
           NPM_CONFIG_PROVENANCE: 'true'
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,6 +14,10 @@ Open the [`Release` workflow](https://github.com/amplitude/rrweb/actions/workflo
 
 The `authorize` job enforces branch + actor (write permission required).
 
+### `skipVersion` (recovery)
+
+Set `skipVersion: true` to skip the `lerna version` step and only run `lerna publish from-git`. Use this when a previous run pushed the version-bump commit + tag but the publish step failed — re-running with `skipVersion: true` republishes from the existing tag without bumping again.
+
 ## Prerelease lifecycle
 
 Prereleases ride a short-lived `alpha` branch:
@@ -113,4 +117,8 @@ Lerna reads `version` from `lerna.json`. Confirm it matches the latest published
 
 ### Tag pushed but no GitHub Release / npm publish
 
-Check the workflow logs for failures after the `Version` step. The tag and commit on the branch are the source of truth for what was attempted; partial failures can be recovered by re-running `Publish` with the same git state via `lerna publish from-git`.
+Check the workflow logs for failures after the `Version` step. The tag and commit on the branch are the source of truth for what was attempted; partial failures can be recovered by re-running the workflow with the same `releaseType` and `skipVersion: true` — this calls `lerna publish from-git` against the existing tag without re-bumping.
+
+### `npm publish` fails with `E404 Not found`
+
+Auth isn't reaching the npm registry. The `actions/setup-node` step writes an `.npmrc` with `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` — if `NODE_AUTH_TOKEN` isn't set on the publish step's env, npm authenticates with a literal placeholder and the registry returns 404 (treating the request as anonymous). Confirm the Publish steps in `release.yml` set `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`.


### PR DESCRIPTION
## Summary

Recovers the failed 2.1.1 publish and adds the missing piece that caused it.

## What happened

First post-merge release of #114 partially succeeded:
- `lerna version` pushed `chore(release): v2.1.1` commit + `v2.1.1` tag to the default branch via the deploy key ✅
- `lerna publish` failed with `E404 Not found` from npm on the very first package ❌

Root cause: `actions/setup-node` (with `registry-url`) writes an `.npmrc` containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`. We never set `NODE_AUTH_TOKEN` in the env, so npm authenticated with the literal placeholder string — the registry treated the request as anonymous and returned 404. (`NPM_TOKEN` already exists on the repo; PR #110 flagged it as the OIDC fallback.)

## Fixes

- Add `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` to both Publish steps.
- Add a `skipVersion: boolean` workflow input. When true, the Version step is skipped and only `lerna publish from-git` runs against the existing tag. Mirrors Amplitude-TypeScript's `skipLernaVersion` recovery input.
- Document both in RELEASE.md.

## Recovery plan (after merge)

Trigger Release workflow with `releaseType: release`, `skipVersion: true`. This calls `lerna publish from-git` against the existing `v2.1.1` tag — no re-bump, no second tag. All packages should land on npm under `latest`.

## Test plan

- [ ] CI green
- [ ] Recovery run with skipVersion=true publishes @amplitude/rrweb*@2.1.1 to npm under latest
- [ ] npm view @amplitude/rrweb version returns 2.1.1
- [ ] GitHub Release for v2.1.1 exists with notes