### PR TITLE
fix(release): use lerna publish from-package instead of from-git

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -117,7 +117,7 @@ Lerna reads `version` from `lerna.json`. Confirm it matches the latest published
 
 ### Tag pushed but no GitHub Release / npm publish
 
-Check the workflow logs for failures after the `Version` step. The tag and commit on the branch are the source of truth for what was attempted; partial failures can be recovered by re-running the workflow with the same `releaseType` and `skipVersion: true` — this calls `lerna publish from-git` against the existing tag without re-bumping.
+Check the workflow logs for failures after the `Version` step. The package.json versions on master and the npm registry are the source of truth for what was attempted vs. what landed; partial failures can be recovered by re-running the workflow with the same `releaseType` and `skipVersion: true` — this calls `lerna publish from-package` which compares package.json versions against npm and publishes the diff (idempotent, safe to re-run).
 
 ### `lerna publish` fails with `EUNCOMMIT Working tree has uncommitted changes`
 

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
     "release:version": "lerna version --conventional-commits --yes",
     "release:version:prerelease": "lerna version --conventional-commits --conventional-prerelease --preid alpha --yes",
     "release:version:dry-run": "lerna version --conventional-commits --no-git-tag-version --no-push --yes",
-    "release:publish": "lerna publish from-git --yes",
-    "release:publish:prerelease": "lerna publish from-git --dist-tag alpha --yes"
+    "release:publish": "lerna publish from-package --yes",
+    "release:publish:prerelease": "lerna publish from-package --dist-tag alpha --yes"
   },
   "resolutions": {
     "**/cssom": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",


### PR DESCRIPTION
## Why

The skipVersion recovery on PR #116 ran the workflow successfully but published **nothing** to npm — `lerna publish from-git` reported `No tagged release found` and exited 0.

`from-git` finds the git tag pointing at HEAD and publishes matching versions. In the normal flow this works because `lerna version` moves HEAD to the tagged commit immediately before publish. But in recovery flow HEAD has advanced past the release tag (PR #116's merge moved HEAD beyond `v2.1.1`), so `from-git` finds no tag at HEAD and silently no-ops.

## Fix

Switch to `lerna publish from-package`, which compares each `package.json` version against the npm registry and publishes whatever's missing. Idempotent, recovery-friendly, works regardless of where HEAD sits relative to release tags.

## Test plan

- [ ] CI green
- [ ] Re-trigger Release workflow with `releaseType=release, skipVersion=true`
- [ ] `npm view @amplitude/rrweb version` returns `2.1.1`
- [ ] All 19 publishable packages now at `2.1.1` on npm under `latest`