### PR TITLE
chore(release): disable provenance and add npm auth diagnostics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,16 +114,24 @@ jobs:
         if: ${{ github.event.inputs.releaseType == 'dry-run' }}
         run: yarn release:version:dry-run
 
+      - name: Verify npm auth
+        if: ${{ github.event.inputs.releaseType != 'dry-run' }}
+        run: |
+          echo "npm whoami:"
+          npm whoami || echo "(npm whoami failed)"
+          echo "access ls-packages:"
+          npm access ls-packages 2>&1 | head -30 || echo "(ls-packages failed)"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Publish (release)
         if: ${{ github.event.inputs.releaseType == 'release' }}
         run: yarn release:publish
         env:
-          NPM_CONFIG_PROVENANCE: 'true'
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish (prerelease)
         if: ${{ github.event.inputs.releaseType == 'prerelease' }}
         run: yarn release:publish:prerelease
         env:
-          NPM_CONFIG_PROVENANCE: 'true'
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Recovery publish keeps failing with \`E404 Not found\` on @amplitude/rrweb even with NPM_TOKEN substituted (confirmed via env logs showing NODE_AUTH_TOKEN: \`***\`). PR #109's changesets-based publish of 2.1.0 succeeded without provenance, so suspect the \`NPM_CONFIG_PROVENANCE\` + token combination is the issue — provenance attestation expects OIDC trusted publishing to be configured npm-side, which may not be set up for this workflow.

## Changes

- Remove \`NPM_CONFIG_PROVENANCE: 'true'\` from Publish steps (matches the config that worked for 2.1.0)
- Add \`Verify npm auth\` step that runs \`npm whoami\` and \`npm access ls-packages\` before publish — diagnostics for token validity / scope

Provenance can be re-added once we either configure npm-side trusted publishing for this workflow or resolve the conflict.

Recovery plan after merge: re-trigger with \`releaseType=release, skipVersion=true\`. The verify step will print auth state; if npm whoami succeeds, the publish should follow.