### PR TITLE
fix(release): restore OIDC trusted publishing by removing token poisoning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,11 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24.x
-          registry-url: 'https://registry.npmjs.org'
+          # Intentionally no registry-url: setup-node writes an .npmrc with
+          # `_authToken=${NODE_AUTH_TOKEN}` when that's set, which causes npm
+          # to use that token instead of attempting OIDC trusted publishing.
+          # OIDC trusted publishing is configured npm-side for this workflow
+          # (SR-3110, PR #89) and is the only auth path we want.
 
       - name: Upgrade npm for OIDC support
         run: npm install -g npm@latest
@@ -114,24 +118,14 @@ jobs:
         if: ${{ github.event.inputs.releaseType == 'dry-run' }}
         run: yarn release:version:dry-run
 
-      - name: Verify npm auth
-        if: ${{ github.event.inputs.releaseType != 'dry-run' }}
-        run: |
-          echo "npm whoami:"
-          npm whoami || echo "(npm whoami failed)"
-          echo "access ls-packages:"
-          npm access ls-packages 2>&1 | head -30 || echo "(ls-packages failed)"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Publish (release)
         if: ${{ github.event.inputs.releaseType == 'release' }}
         run: yarn release:publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: 'true'
 
       - name: Publish (prerelease)
         if: ${{ github.event.inputs.releaseType == 'prerelease' }}
         run: yarn release:publish:prerelease
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: 'true'

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -128,6 +128,7 @@ Build prepublish hooks mutate tracked files (notably the `tsconfig.json` project
 OIDC trusted publishing isn't being used. npm publishing for this repo is configured to use [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers) (SR-3110, PR #89) — no static NPM_TOKEN should be in the publish flow. If `actions/setup-node` is configured with `registry-url:`, it writes an `.npmrc` containing `_authToken=${NODE_AUTH_TOKEN}`; whenever an authToken is present, npm uses it (or its placeholder) instead of attempting OIDC, and the registry returns 404 for the publish.
 
 Confirm in `release.yml`:
+
 - `actions/setup-node` does NOT set `registry-url:`
 - Publish steps do NOT set `NODE_AUTH_TOKEN`
 - `id-token: write` is in `permissions:` (so the OIDC token is available)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -125,4 +125,10 @@ Build prepublish hooks mutate tracked files (notably the `tsconfig.json` project
 
 ### `npm publish` fails with `E404 Not found`
 
-Auth isn't reaching the npm registry. The `actions/setup-node` step writes an `.npmrc` with `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` — if `NODE_AUTH_TOKEN` isn't set on the publish step's env, npm authenticates with a literal placeholder and the registry returns 404 (treating the request as anonymous). Confirm the Publish steps in `release.yml` set `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`.
+OIDC trusted publishing isn't being used. npm publishing for this repo is configured to use [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers) (SR-3110, PR #89) — no static NPM_TOKEN should be in the publish flow. If `actions/setup-node` is configured with `registry-url:`, it writes an `.npmrc` containing `_authToken=${NODE_AUTH_TOKEN}`; whenever an authToken is present, npm uses it (or its placeholder) instead of attempting OIDC, and the registry returns 404 for the publish.
+
+Confirm in `release.yml`:
+- `actions/setup-node` does NOT set `registry-url:`
+- Publish steps do NOT set `NODE_AUTH_TOKEN`
+- `id-token: write` is in `permissions:` (so the OIDC token is available)
+- `NPM_CONFIG_PROVENANCE: 'true'` on the Publish step (provenance attestation via OIDC)


### PR DESCRIPTION
## Why

npm OIDC trusted publishing was configured for this repo's `.github/workflows/release.yml` workflow in PR #89 / SR-3110 (Mar 2026, coordinated with Lakshmanan Murthy). The 2.1.0 publish via changesets-action used it successfully — the SLSA provenance attestation on `@amplitude/rrweb@2.1.0` confirms it.

My recent fix attempts (#115, #118) added `NODE_AUTH_TOKEN` + `registry-url` thinking the token was the missing piece. That actually broke OIDC: `setup-node` with `registry-url` writes an `.npmrc` containing `_authToken=${NODE_AUTH_TOKEN}`, and whenever npm sees an explicit authToken it uses that instead of attempting OIDC. The token in our `NPM_TOKEN` secret is stale (Security's Dec 2025 sweep revoked legacy tokens per the Shai-Hulud 2.0 hardening) so npm returns 401 on whoami → 404 on publish.

## Fix

- Drop `registry-url:` from setup-node so no .npmrc is generated
- Drop `NODE_AUTH_TOKEN:` from both Publish steps
- Drop the diagnostic "Verify npm auth" step (it did its job, exposed the 401)
- Re-enable `NPM_CONFIG_PROVENANCE: 'true'` so publishes carry provenance attestations

With this, npm 11.5.1+ (installed by "Upgrade npm for OIDC support") authenticates via the GitHub OIDC token automatically — same path that worked for 2.1.0.

Update RELEASE.md troubleshooting for the new failure mode.

## Test plan

- [ ] CI green
- [ ] After merge, trigger Release workflow with `releaseType=release, skipVersion=true`
- [ ] @amplitude/rrweb*@2.1.1 lands on npm under `latest`
- [ ] Provenance attestation present on the new versions

Linear: SR-4223

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the GitHub Actions release workflow’s npm authentication/provenance behavior; mistakes could block publishing or produce releases without provenance.
> 
> **Overview**
> Restores npm **OIDC trusted publishing** in the `Release` GitHub Actions workflow by removing `actions/setup-node` `registry-url` configuration and dropping `NODE_AUTH_TOKEN` usage in publish steps (avoids generating an `.npmrc` that forces token auth).
> 
> Removes the temporary "Verify npm auth" diagnostic step and re-enables provenance attestations by setting `NPM_CONFIG_PROVENANCE: 'true'` during publishes. Updates `RELEASE.md` troubleshooting to document the OIDC-specific failure mode and required workflow settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0d6b78b406ea8cb7ca790155e943fd720073571. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->