### PR TITLE
chore(release): enable verbose npm logging + serial publish for diagnosis

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,12 +120,14 @@ jobs:
 
       - name: Publish (release)
         if: ${{ github.event.inputs.releaseType == 'release' }}
-        run: yarn release:publish
+        run: yarn release:publish -- --concurrency 1
         env:
           NPM_CONFIG_PROVENANCE: 'true'
+          NPM_CONFIG_LOGLEVEL: verbose
 
       - name: Publish (prerelease)
         if: ${{ github.event.inputs.releaseType == 'prerelease' }}
-        run: yarn release:publish:prerelease
+        run: yarn release:publish:prerelease -- --concurrency 1
         env:
           NPM_CONFIG_PROVENANCE: 'true'
+          NPM_CONFIG_LOGLEVEL: verbose


### PR DESCRIPTION
## Why

Recovery publishes of 2.1.1 keep failing with `E404 Not found` on `@amplitude/rrweb` even after PR #119 removed the NPM_TOKEN poisoning. The 2.1.0 publish via changesets-action worked over OIDC (SLSA attestations confirm it), so npm-side trusted publishing config exists for this workflow. The actual npm error is hidden behind lerna's terse wrapper.

## Changes

- `NPM_CONFIG_LOGLEVEL=verbose` on both Publish step env — surfaces underlying npm output (OIDC token requests, registry responses, etc.)
- `--concurrency 1` on `lerna publish` — sequential publishes so output isn't interleaved across worker processes; clearer which package fails at which step

## Recovery plan after merge

Trigger Release workflow with `releaseType=release, skipVersion=true`. Examine the verbose logs to see what npm responds with. Once we know, the real fix should be one line — common candidates:
- OIDC token isn't being requested → lerna's worker isn't inheriting env (fix: explicitly pass through ACTIONS_ID_TOKEN_REQUEST_*)
- OIDC token is sent but rejected → npm-side trusted publisher config needs adjustment (involve Lakshmanan/Dan)
- Some other auth path is being used → narrow it down from logs

This PR is diagnostic-only and meant to be reverted (or the loglevel removed) once we've identified the real fix.

Linear: SR-4223

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect the production release/publish pipeline; while intended to be diagnostic, serializing publishes and increasing log verbosity could alter timing and expose more operational detail in CI logs.
> 
> **Overview**
> Updates `.github/workflows/release.yml` to run `yarn release:publish`/`yarn release:publish:prerelease` with `--concurrency 1`, making Lerna publishes run sequentially for clearer failure attribution.
> 
> Also sets `NPM_CONFIG_LOGLEVEL=verbose` for both publish steps (alongside provenance) to surface underlying npm/OIDC/registry output during release troubleshooting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1833e8b6811f07a67f7f215fbdd506013948d1b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->