### PR TITLE
fix(release): publish via npm CLI to get full OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,16 +118,20 @@ jobs:
         if: ${{ github.event.inputs.releaseType == 'dry-run' }}
         run: yarn release:version:dry-run
 
+      # Publish via the npm CLI directly rather than `lerna publish`, because
+      # lerna 8.2.4 bundles libnpmpublish 9.x which only supports OIDC for
+      # provenance generation, not for trusted-publisher auth (added in
+      # libnpmpublish 11.x and shipped with npm 11.5.1+). The npm CLI installed
+      # by "Upgrade npm for OIDC support" above has the full OIDC auth flow.
+      # We still use `lerna list` for topological ordering across the workspace.
       - name: Publish (release)
         if: ${{ github.event.inputs.releaseType == 'release' }}
-        run: yarn release:publish -- --concurrency 1
+        run: bash scripts/publish-packages.sh
         env:
           NPM_CONFIG_PROVENANCE: 'true'
-          NPM_CONFIG_LOGLEVEL: verbose
 
       - name: Publish (prerelease)
         if: ${{ github.event.inputs.releaseType == 'prerelease' }}
-        run: yarn release:publish:prerelease -- --concurrency 1
+        run: bash scripts/publish-packages.sh alpha
         env:
           NPM_CONFIG_PROVENANCE: 'true'
-          NPM_CONFIG_LOGLEVEL: verbose

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -125,11 +125,16 @@ Build prepublish hooks mutate tracked files (notably the `tsconfig.json` project
 
 ### `npm publish` fails with `E404 Not found`
 
-OIDC trusted publishing isn't being used. npm publishing for this repo is configured to use [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers) (SR-3110, PR #89) — no static NPM_TOKEN should be in the publish flow. If `actions/setup-node` is configured with `registry-url:`, it writes an `.npmrc` containing `_authToken=${NODE_AUTH_TOKEN}`; whenever an authToken is present, npm uses it (or its placeholder) instead of attempting OIDC, and the registry returns 404 for the publish.
+OIDC trusted publishing isn't reaching the registry. npm publishing for this repo is configured to use [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers) (SR-3110, PR #89) — no static NPM_TOKEN should be in the publish flow. Common causes:
+
+1. **`actions/setup-node` writes a poisoned `.npmrc`.** When configured with `registry-url:`, setup-node writes `_authToken=${NODE_AUTH_TOKEN}`. If an authToken is present (even a placeholder or stale value), npm uses it instead of attempting OIDC, and the registry returns 404. Confirm `actions/setup-node` does **not** set `registry-url:` and Publish steps do **not** set `NODE_AUTH_TOKEN`.
+
+2. **The publish tool bundles an old `libnpmpublish`.** `libnpmpublish` 9.x and earlier only support OIDC for _provenance generation_, not for _auth_. OIDC trusted-publisher token exchange was added in libnpmpublish 11.x (shipped with npm 11.5.1+). Lerna 8.2.4 bundles libnpmpublish 9.x — that's why this repo publishes via `scripts/publish-packages.sh` (shells out to the npm CLI, which has the full OIDC auth flow) rather than `lerna publish`.
 
 Confirm in `release.yml`:
 
 - `actions/setup-node` does NOT set `registry-url:`
 - Publish steps do NOT set `NODE_AUTH_TOKEN`
 - `id-token: write` is in `permissions:` (so the OIDC token is available)
-- `NPM_CONFIG_PROVENANCE: 'true'` on the Publish step (provenance attestation via OIDC)
+- `NPM_CONFIG_PROVENANCE: 'true'` on the Publish step (provenance attestation)
+- Publish uses the npm CLI (via `scripts/publish-packages.sh`), not `lerna publish`

--- a/package.json
+++ b/package.json
@@ -57,9 +57,7 @@
     "lint:report": "yarn eslint --output-file eslint_report.json --format json packages/*/src --ext .ts,.tsx,.js,.jsx",
     "release:version": "lerna version --conventional-commits --yes",
     "release:version:prerelease": "lerna version --conventional-commits --conventional-prerelease --preid alpha --yes",
-    "release:version:dry-run": "lerna version --conventional-commits --no-git-tag-version --no-push --yes",
-    "release:publish": "lerna publish from-package --yes",
-    "release:publish:prerelease": "lerna publish from-package --dist-tag alpha --yes"
+    "release:version:dry-run": "lerna version --conventional-commits --no-git-tag-version --no-push --yes"
   },
   "resolutions": {
     "**/cssom": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Publish all non-private workspace packages to npm via the npm CLI.
+#
+# Why not `lerna publish`?
+#   lerna 8.2.4 bundles libnpmpublish 9.x, whose OIDC support is limited to
+#   provenance signing — it does not implement trusted-publisher token
+#   exchange for auth (added in libnpmpublish 11.x). Calling the npm CLI
+#   directly gets us npm 11.5.1+'s full OIDC trusted-publishing flow.
+#
+# Behaviour:
+#   - Iterates packages in topological order (deps before dependents)
+#   - Skips packages whose current package.json version is already on npm
+#     (idempotent — safe to re-run after a partial publish)
+#   - Runs the package's prepublish / prepublishOnly / prepack lifecycle
+#     hooks as part of each `npm publish` invocation
+#
+# Usage:
+#   scripts/publish-packages.sh             # publish under the default tag (latest)
+#   scripts/publish-packages.sh alpha       # publish under the alpha dist-tag
+#
+# Env:
+#   NPM_CONFIG_PROVENANCE=true   request provenance attestation
+#   ACTIONS_ID_TOKEN_REQUEST_*   set by GitHub Actions when id-token: write
+#                                permission is granted; npm uses these to
+#                                exchange for an npm publish credential
+
+set -euo pipefail
+
+DIST_TAG="${1:-}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+# Topologically sorted list of non-private workspace packages.
+packages_json="$(yarn -s lerna list --json --toposort --no-private)"
+
+echo "$packages_json" | jq -c '.[]' | while IFS= read -r entry; do
+  name="$(echo "$entry" | jq -r '.name')"
+  version="$(echo "$entry" | jq -r '.version')"
+  location="$(echo "$entry" | jq -r '.location')"
+
+  # Check if this exact version is already on the registry.
+  if npm view "${name}@${version}" version >/dev/null 2>&1; then
+    echo "  ✓ ${name}@${version} already on npm — skipping"
+    continue
+  fi
+
+  echo "  ▶ Publishing ${name}@${version}"
+  (
+    cd "$location"
+    if [ -n "$DIST_TAG" ]; then
+      npm publish --provenance --access public --tag "$DIST_TAG"
+    else
+      npm publish --provenance --access public
+    fi
+  )
+done
+
+echo "Publish complete."


### PR DESCRIPTION
## Root cause

Lerna 8.2.4 bundles `libnpmpublish@9.0.9`. That version supports OIDC **only for provenance generation**, not for **trusted-publisher token exchange (auth)**. The auth flow was added in `libnpmpublish` 11.x and ships with npm 11.5.1+.

Every `lerna publish from-package` against our OIDC-trusted registry has been returning `E404 Not found` because the request is effectively anonymous — the OIDC token never gets exchanged for a publish credential.

PR #109's 2.1.0 publish worked because `changesets-action` shells out to the npm CLI, which bundles a recent libnpmpublish with full OIDC auth.

## Fix

Replace `yarn release:publish` / `:prerelease` with `scripts/publish-packages.sh` — a small bash script that:

- Lists non-private workspace packages in topological order via `lerna list --json --toposort --no-private`
- For each, skips if `name@version` is already on the registry (idempotent — safe to re-run for partial-publish recovery)
- Shells out to `npm publish --provenance --access public` (plus `--tag <dist-tag>` for prereleases) — uses the npm CLI installed by "Upgrade npm for OIDC support" which has libnpmpublish 11.x

Lerna is still used for `lerna version` (handles bump + tag + commit + GitHub Release) and `lerna list` (topo ordering). Only the publish path bypasses Lerna's bundled library.

## Cleanup

- Drop `release:publish` / `release:publish:prerelease` package.json scripts (no longer called)
- Drop `NPM_CONFIG_LOGLEVEL: verbose` (was diagnostic for #120)
- RELEASE.md E404 troubleshooting now covers the libnpmpublish-version cause

## Test plan

- [ ] CI green
- [ ] After merge: trigger Release workflow with `releaseType=release, skipVersion=true`
- [ ] All `@amplitude/rrweb*` packages at `2.1.1` on npm under `latest`
- [ ] Provenance attestations present on the new versions
- [ ] Re-running the workflow is a no-op (idempotent skip)

Linear: SR-4223

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the CI release/publish mechanism across all packages; failures could block releases or publish under the wrong tag, though the script is idempotent and still relies on Lerna for ordering/versioning.
> 
> **Overview**
> **Release publishing now bypasses `lerna publish`** and uses the npm CLI to ensure full OIDC trusted-publisher authentication (and provenance) works in GitHub Actions.
> 
> The `Release` workflow replaces `yarn release:publish*` with `scripts/publish-packages.sh`, which publishes workspace packages in `lerna list --toposort` order and skips versions already present on npm (safe to re-run). Related cleanup removes the unused `release:publish` scripts from `package.json` and updates `RELEASE.md` troubleshooting to document the libnpmpublish/OIDC failure mode and the new publish path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72f766b4dff1b37d03dacc66e1af3a37a9a65de2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->