### PR TITLE
chore(release): gate publish on tests passing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,12 @@ jobs:
         env:
           NODE_OPTIONS: '--max-old-space-size=4096'
 
+      - name: Run tests
+        # Gate publish on tests passing. Skipped for dry-run since dry-run
+        # is just a version-bump preview, not an actual release.
+        if: ${{ github.event.inputs.releaseType != 'dry-run' }}
+        run: yarn test
+
       - name: Reset working tree
         # Build prepublish hooks mutate tracked files (tsconfig project references).
         # Reset so `lerna version` doesn't fold them into the release commit and


### PR DESCRIPTION
## Why

The release workflow currently trusts the default branch state — if a commit lands via admin bypass without its PR tests passing (which happened during the SR-4223 chain), the next release publishes it anyway. Adding a tests gate inside the release workflow protects against that.

## Changes

Add a `Run tests` step between `Build packages` and `Reset working tree`:

- Runs `yarn test` (same script CI runs on PRs)
- Skipped for `releaseType=dry-run` — that's just a version-bump preview, not an actual publish
- Runs for `release` and `prerelease`

## Trade-offs

- Adds ~test-duration to release runs (currently a few minutes for the rrweb monorepo)
- Reuses the build artifacts already produced by `Build packages`, so no redundant work
- Sequential in the same job rather than a separate `Tests` job — simpler, no artifact sharing needed

Linear: SR-4223

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; main impact is longer release runs and potential release blockage if the test suite is flaky or environment-dependent.
> 
> **Overview**
> **Release workflow now runs tests before publishing.** It inserts a `yarn test` step after `yarn build:all` and before resetting the working tree, and skips this step for `releaseType=dry-run` so dry-runs remain version-bump previews only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 040420049b004c5666baf58ed00ff4c313d9183d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->