### PR TITLE
feat(rrweb): add opt-in freezeTransitions replayer option

### DIFF
--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -102,6 +102,13 @@ const REPLAY_CONSOLE_PREFIX = '[replayer]';
 
 const INJECTED_STYLE_ID = '__rrweb-injected-style__';
 
+// Disables CSS transitions in the replay iframe when `freezeTransitions` is
+// enabled. Mirrors the transition half of the capture-side `freezeAnimations()`
+// CSS (see packages/capture/src/dom-utils.ts). Suppresses crossfade artifacts
+// from per-frame inline-style opacity/transform animations during replay.
+const FREEZE_TRANSITIONS_CSS =
+  '*, *::before, *::after { transition-duration: 0s !important; transition-delay: 0s !important; }';
+
 const defaultMouseTailConfig = {
   duration: 500,
   lineCap: 'round',
@@ -216,6 +223,7 @@ export class Replayer {
       triggerFocus: true,
       UNSAFE_replayCanvas: false,
       pauseAnimation: true,
+      freezeTransitions: false,
       mouseTail: defaultMouseTailConfig,
       useVirtualDom: true, // Virtual-dom optimization is enabled by default.
       useSeekCache: false, // Opt-in until production-validated; flip to true once confidence is high.
@@ -1107,6 +1115,9 @@ export class Replayer {
         'html.rrweb-paused *, html.rrweb-paused *:before, html.rrweb-paused *:after { animation-play-state: paused !important; }',
       );
     }
+    if (this.config.freezeTransitions) {
+      injectStylesRules.push(FREEZE_TRANSITIONS_CSS);
+    }
     if (!injectStylesRules.length) {
       return;
     }
@@ -1144,6 +1155,9 @@ export class Replayer {
     const injectStylesRules = getInjectStyleRules(
       this.config.blockClass,
     ).concat(this.config.insertStyleRules);
+    if (this.config.freezeTransitions) {
+      injectStylesRules.push(FREEZE_TRANSITIONS_CSS);
+    }
 
     if (!injectStylesRules.length) return;
 

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -198,6 +198,27 @@ export type playerConfig = {
   triggerFocus: boolean;
   UNSAFE_replayCanvas: boolean;
   pauseAnimation?: boolean;
+  /**
+   * When `true`, the replayer injects a stylesheet into the replay iframe (and
+   * any shadow roots) that disables CSS transitions:
+   *
+   * ```css
+   * *, *::before, *::after {
+   *   transition-duration: 0s !important;
+   *   transition-delay: 0s !important;
+   * }
+   * ```
+   *
+   * This suppresses crossfade/transition artifacts that occur when a page
+   * animates between sibling elements via per-frame inline `style`
+   * (e.g. two `position: absolute; width: 100%` nodes whose `opacity`/
+   * `transform` is updated across several incremental mutations). Without this,
+   * replay can show both nodes mid-transition stacked on top of one another.
+   *
+   * Mirrors the transition half of the capture-side `freezeAnimations()` CSS.
+   * Opt-in; default `false` so existing replay behavior is unchanged.
+   */
+  freezeTransitions?: boolean;
   mouseTail:
     | boolean
     | {

--- a/packages/rrweb/test/replay/freeze-transitions.test.ts
+++ b/packages/rrweb/test/replay/freeze-transitions.test.ts
@@ -1,0 +1,178 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for the opt-in `freezeTransitions` replayer option.
+ *
+ * Fixture: two `position: absolute; width: 100%` sibling nodes whose inline
+ * `style` crossfades `opacity` across several incremental mutations — the exact
+ * shape that produces stacked, mid-crossfade text in replay. With
+ * `freezeTransitions: true` the replayer must inject a stylesheet into the
+ * replay iframe that zeroes out `transition-duration`, suppressing the artifact.
+ * With the option off (default) no such rule is injected.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { EventType, IncrementalSource } from '@amplitude/rrweb-types';
+import type { eventWithTime } from '@amplitude/rrweb-types';
+import { Replayer } from '../../src/replay';
+
+const T0 = 1_000_000;
+
+// ids: document=1, html=2, head=3, body=4, slideA=5, slideB=6
+const SLIDE_A_ID = 5;
+const SLIDE_B_ID = 6;
+
+function absoluteSlide(id: number, opacity: number) {
+  return {
+    type: 2, // Element
+    tagName: 'div',
+    attributes: {
+      style: `position: absolute; width: 100%; opacity: ${opacity}; transition: opacity 0.3s ease;`,
+    },
+    childNodes: [
+      {
+        type: 3, // Text
+        textContent: id === SLIDE_A_ID ? 'Slide A' : 'Slide B',
+        id: id + 100,
+      },
+    ],
+    id,
+  };
+}
+
+function makeEvents(): eventWithTime[] {
+  const events: eventWithTime[] = [
+    { type: EventType.DomContentLoaded, data: {}, timestamp: T0 },
+    { type: EventType.Load, data: {}, timestamp: T0 },
+    {
+      type: EventType.Meta,
+      data: { href: 'http://localhost', width: 800, height: 600 },
+      timestamp: T0,
+    },
+    {
+      type: EventType.FullSnapshot,
+      data: {
+        node: {
+          type: 0,
+          childNodes: [
+            {
+              type: 2,
+              tagName: 'html',
+              attributes: {},
+              childNodes: [
+                { type: 2, tagName: 'head', attributes: {}, childNodes: [], id: 3 },
+                {
+                  type: 2,
+                  tagName: 'body',
+                  attributes: {},
+                  childNodes: [
+                    absoluteSlide(SLIDE_A_ID, 1),
+                    absoluteSlide(SLIDE_B_ID, 0),
+                  ],
+                  id: 4,
+                },
+              ],
+              id: 2,
+            },
+          ],
+          id: 1,
+        },
+        initialOffset: { top: 0, left: 0 },
+      },
+      timestamp: T0,
+    },
+  ];
+
+  // Crossfade A→B over several per-frame inline-style mutations.
+  for (let i = 1; i <= 5; i++) {
+    const t = i / 5; // 0.2 .. 1.0
+    events.push({
+      type: EventType.IncrementalSnapshot,
+      data: {
+        source: IncrementalSource.Mutation,
+        texts: [],
+        attributes: [
+          {
+            id: SLIDE_A_ID,
+            attributes: {
+              style: `position: absolute; width: 100%; opacity: ${1 - t}; transition: opacity 0.3s ease;`,
+            },
+          },
+          {
+            id: SLIDE_B_ID,
+            attributes: {
+              style: `position: absolute; width: 100%; opacity: ${t}; transition: opacity 0.3s ease;`,
+            },
+          },
+        ],
+        removes: [],
+        adds: [],
+      },
+      timestamp: T0 + i * 60,
+    } as eventWithTime);
+  }
+
+  return events;
+}
+
+function makeReplayer(opts: Record<string, unknown> = {}) {
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+  const replayer = new Replayer(makeEvents(), {
+    root,
+    showWarning: false,
+    showDebug: false,
+    // Force the real-DOM rebuild path so insertStyleRules materializes a
+    // <style> element in the iframe (the virtual-dom path keeps rules in an
+    // in-memory tree that isn't synchronously diffed here).
+    useVirtualDom: false,
+    logger: { log: () => {}, warn: () => {} },
+    ...opts,
+  });
+  return replayer;
+}
+
+// Collect the CSS text injected into every <style> element of the replay iframe,
+// reading both `textContent` and any CSSOM rules (the non-virtual path uses
+// `sheet.insertRule`, which leaves `textContent` empty).
+function injectedIframeCss(replayer: Replayer): string {
+  const doc = replayer.iframe.contentDocument!;
+  let css = '';
+  doc.querySelectorAll('style').forEach((styleEl) => {
+    css += styleEl.textContent ?? '';
+    const sheet = styleEl.sheet;
+    if (sheet) {
+      for (let i = 0; i < sheet.cssRules.length; i++) {
+        css += sheet.cssRules[i].cssText;
+      }
+    }
+  });
+  return css;
+}
+
+describe('Replayer freezeTransitions option', () => {
+  vi.useFakeTimers();
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('injects a transition-disabling rule when freezeTransitions is true', async () => {
+    const replayer = makeReplayer({ freezeTransitions: true });
+    // Let the mount-time poster rebuild fire (setTimeout(…, 1)), which runs
+    // insertStyleRules and materializes the injected <style> in the iframe.
+    await vi.runAllTimersAsync();
+
+    const css = injectedIframeCss(replayer);
+    expect(css).toContain('transition-duration: 0s');
+    expect(css).toContain('transition-delay: 0s');
+  });
+
+  it('does not inject a transition-disabling rule by default', async () => {
+    const replayer = makeReplayer();
+    await vi.runAllTimersAsync();
+
+    const css = injectedIframeCss(replayer);
+    expect(css).not.toContain('transition-duration: 0s');
+  });
+});

--- a/packages/rrweb/test/replay/freeze-transitions.test.ts
+++ b/packages/rrweb/test/replay/freeze-transitions.test.ts
@@ -59,7 +59,13 @@ function makeEvents(): eventWithTime[] {
               tagName: 'html',
               attributes: {},
               childNodes: [
-                { type: 2, tagName: 'head', attributes: {}, childNodes: [], id: 3 },
+                {
+                  type: 2,
+                  tagName: 'head',
+                  attributes: {},
+                  childNodes: [],
+                  id: 3,
+                },
                 {
                   type: 2,
                   tagName: 'body',
@@ -94,7 +100,9 @@ function makeEvents(): eventWithTime[] {
           {
             id: SLIDE_A_ID,
             attributes: {
-              style: `position: absolute; width: 100%; opacity: ${1 - t}; transition: opacity 0.3s ease;`,
+              style: `position: absolute; width: 100%; opacity: ${
+                1 - t
+              }; transition: opacity 0.3s ease;`,
             },
           },
           {


### PR DESCRIPTION
## Summary

Adds an opt-in replayer config option, `freezeTransitions` (default `false`), that injects a transition-disabling stylesheet into the replay iframe — and any shadow roots, via the existing `insertStyleRulesIntoShadowRoot` path:

```css
*, *::before, *::after {
  transition-duration: 0s !important;
  transition-delay: 0s !important;
}
```

This suppresses the "stacked crossfade text" artifact that occurs when a page crossfades two `position: absolute; width: 100%` siblings by updating per-frame inline `style` (opacity/transform) across several incremental mutations. Without freezing, replay re-triggers CSS transitions on each style mutation and can render both nodes mid-transition on top of one another.

The CSS mirrors the transition half of the capture-side `freezeAnimations()` (`packages/capture/src/dom-utils.ts`) for parity. Default behavior is unchanged — the rule is only injected when a consumer opts in.

### Changes
- `packages/rrweb/src/types.ts`: add `freezeTransitions?: boolean` to `playerConfig` (documented).
- `packages/rrweb/src/replay/index.ts`: default `freezeTransitions: false`; inject `FREEZE_TRANSITIONS_CSS` in both `insertStyleRules` (iframe) and `insertStyleRulesIntoShadowRoot` (shadow roots) when enabled.
- `packages/rrweb/test/replay/freeze-transitions.test.ts`: new jsdom test.

## Test plan

Run from the repo root (after `pnpm install` + building the rrweb workspace deps):

- `pnpm --filter @amplitude/rrweb build` — ✅ pass (includes `tsc -noEmit`)
- `pnpm --filter @amplitude/rrweb exec vitest run test/replay/freeze-transitions.test.ts` — ✅ 2 passed
- `pnpm --filter @amplitude/rrweb check-types` — ✅ pass
- `pnpm --filter @amplitude/rrweb lint` — ✅ 0 errors (pre-existing warnings only)

The new test builds a fixture with two `position: absolute; width: 100%` siblings whose inline `style` crossfades `opacity` across several incremental mutations, then asserts that with `freezeTransitions: true` the injected iframe stylesheet contains `transition-duration: 0s` / `transition-delay: 0s`, and that the default (option off) injects no such rule.

## Deferred follow-up

The larger **record-time** fix — per-`(nodeId, property)` style coalescing in `packages/.../mutation.ts` so per-frame inline-style churn is collapsed before it reaches the replayer — is intentionally **not** in this PR to keep it small and reviewable. This replay-side opt-in is shippable on its own; the record-time coalescing can follow as a separate change.

> Note: this repo uses Lerna + conventional-commit PR titles for releases (no changesets), so the version bump is driven by the `feat(rrweb): ...` title rather than a `.changeset/` file.

Linear: https://linear.app/amplitude/issue/SR-4656

Made with [Cursor](https://cursor.com)