### PR TITLE
fix(rrweb-snapshot): serialize grid-template-areas faithfully to fix mobile replay text overlap (SR-4667)

### DIFF
--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -63,6 +63,74 @@ function fixBrowserCompatibilityIssuesInCSS(cssText: string): string {
   return cssText;
 }
 
+/**
+ * Some browsers (notably Chrome) serialize the `grid` / `grid-template`
+ * shorthand lossily in `CSSStyleRule.cssText`: when a multi-row
+ * `grid-template-areas` value is combined with named grid lines/areas, the
+ * serialized text can collapse to a single-row template (or drop the named
+ * areas entirely). Children pinned to those areas via `grid-row-start` /
+ * `grid-column-start` then fall back onto one implicit cell and overlap on
+ * replay (root cause of SR-4667 — GoFundMe mobile text overlap).
+ *
+ * The CSSOM longhands (`grid-template-areas` / `-rows` / `-columns`) remain
+ * intact on `rule.style` even when `cssText` is lossy, so when the serialized
+ * rule has lost the full areas value we re-emit those longhands read straight
+ * from the CSSOM. Guarded to only act when `grid-template-areas` is present and
+ * actually missing from the serialized text, so it is a no-op for the
+ * overwhelming majority of rules and for engines (jsdom/happy-dom) that
+ * round-trip grid faithfully.
+ * @param rule - the `CSSStyleRule` being serialized
+ * @param cssText - the (possibly lossy) `rule.cssText` output
+ * @returns `cssText` with grid-template longhands restored when needed
+ */
+export function fixGridTemplateSerialization(
+  rule: CSSStyleRule,
+  cssText: string,
+): string {
+  let style: CSSStyleDeclaration | undefined;
+  try {
+    style = rule.style;
+  } catch (error) {
+    return cssText;
+  }
+  if (!style || typeof style.getPropertyValue !== 'function') {
+    return cssText;
+  }
+
+  const areas = style.getPropertyValue('grid-template-areas');
+  // Only multi-area grid templates are at risk of lossy serialization;
+  // `none`/empty means there is nothing to recover.
+  if (!areas || areas === 'none') {
+    return cssText;
+  }
+
+  // If the serialized rule already contains the full areas value, nothing was
+  // lost (e.g. the author used the longhand, or the engine round-trips it).
+  if (normalizeCssString(cssText).includes(normalizeCssString(areas))) {
+    return cssText;
+  }
+
+  const declarations = [`grid-template-areas: ${areas};`];
+  const rows = style.getPropertyValue('grid-template-rows');
+  if (rows) {
+    declarations.push(`grid-template-rows: ${rows};`);
+  }
+  const columns = style.getPropertyValue('grid-template-columns');
+  if (columns) {
+    declarations.push(`grid-template-columns: ${columns};`);
+  }
+
+  // Inject the recovered longhands just before the rule's closing brace.
+  const closingBraceIndex = cssText.lastIndexOf('}');
+  if (closingBraceIndex === -1) {
+    return cssText;
+  }
+  const head = cssText.slice(0, closingBraceIndex).replace(/\s*$/, '');
+  const needsSemicolon =
+    head.length > 0 && !head.endsWith('{') && !head.endsWith(';');
+  return `${head}${needsSemicolon ? ';' : ''} ${declarations.join(' ')} }`;
+}
+
 // Remove this declaration once typescript has added `CSSImportRule.supportsText` to the lib.
 declare interface CSSImportRule extends CSSRule {
   readonly href: string;
@@ -151,10 +219,15 @@ export function stringifyRule(rule: CSSRule, sheetHref: string | null): string {
     return importStringified;
   } else {
     let ruleStringified = rule.cssText;
-    if (isCSSStyleRule(rule) && rule.selectorText.includes(':')) {
-      // Safari does not escape selectors with : properly
-      // see https://bugs.webkit.org/show_bug.cgi?id=184604
-      ruleStringified = fixSafariColons(ruleStringified);
+    if (isCSSStyleRule(rule)) {
+      if (rule.selectorText.includes(':')) {
+        // Safari does not escape selectors with : properly
+        // see https://bugs.webkit.org/show_bug.cgi?id=184604
+        ruleStringified = fixSafariColons(ruleStringified);
+      }
+      // Recover grid-template longhands dropped by lossy shorthand
+      // serialization (SR-4667).
+      ruleStringified = fixGridTemplateSerialization(rule, ruleStringified);
     }
     if (sheetHref) {
       return absolutifyURLs(ruleStringified, sheetHref);

--- a/packages/rrweb-snapshot/test/grid-template.test.ts
+++ b/packages/rrweb-snapshot/test/grid-template.test.ts
@@ -1,0 +1,128 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression coverage for SR-4667: the dominant root cause of the GoFundMe
+ * mobile-web "text rendered on top of itself" replay was a capture-side CSS
+ * serialization gap. Real Chrome serializes the `grid` / `grid-template`
+ * shorthand lossily — a multi-row `grid-template-areas` value combined with
+ * named grid lines collapses to a single-row template in `CSSStyleRule.cssText`,
+ * so children pinned to named areas overlap on replay.
+ *
+ * IMPORTANT TEST-ENV CAVEAT: neither jsdom nor happy-dom reproduces Chrome's
+ * lossy CSSOM serialization. They store the grid shorthand verbatim (which
+ * actually preserves the template) and return "" from
+ * `rule.style.getPropertyValue('grid-template-areas')` for shorthand input.
+ * The original capture-side loss therefore cannot be reproduced here; it can
+ * only be confirmed definitively with a real-Chrome capture. These tests
+ * exercise the defensive fix directly against a simulated lossy rule, plus a
+ * round-trip guard through `stringifyStylesheet`.
+ */
+import { describe, it, expect } from 'vitest';
+import { JSDOM } from 'jsdom';
+import {
+  fixGridTemplateSerialization,
+  stringifyStylesheet,
+} from '../src/utils';
+
+/**
+ * Build a minimal `CSSStyleRule` stand-in that mimics Chrome's behaviour: the
+ * CSSOM longhands are intact, but the serialized `cssText` has dropped the
+ * multi-row areas down to a single-row template.
+ */
+function makeRule(
+  cssText: string,
+  longhands: Record<string, string>,
+): CSSStyleRule {
+  return {
+    selectorText: '.p-campaign',
+    cssText,
+    style: {
+      getPropertyValue: (prop: string) => longhands[prop] ?? '',
+    },
+  } as unknown as CSSStyleRule;
+}
+
+describe('fixGridTemplateSerialization (SR-4667)', () => {
+  it('re-emits grid-template longhands when the serialized rule has collapsed a multi-row areas template', () => {
+    const lossyCssText =
+      '.p-campaign { display: grid; grid-template: "partner-banner" / 1fr; }';
+    const rule = makeRule(lossyCssText, {
+      'grid-template-areas':
+        '"header" "collage" "byline" "content" "description" "sidebar"',
+      'grid-template-rows': 'auto auto auto 1fr auto auto',
+      'grid-template-columns': '1fr',
+    });
+
+    const out = fixGridTemplateSerialization(rule, lossyCssText);
+
+    expect(out).toContain(
+      'grid-template-areas: "header" "collage" "byline" "content" "description" "sidebar"',
+    );
+    expect(out).toContain('grid-template-rows: auto auto auto 1fr auto auto');
+    expect(out).toContain('grid-template-columns: 1fr');
+    // existing declarations are preserved
+    expect(out).toContain('display: grid');
+    // output is still a well-formed single rule
+    expect(out.match(/}/g)).toHaveLength(1);
+    expect(out.trimEnd().endsWith('}')).toBe(true);
+  });
+
+  it('omits grid-template-rows / -columns longhands that are not set', () => {
+    const lossyCssText = '.p-campaign { grid-template: "a" / none; }';
+    const rule = makeRule(lossyCssText, {
+      'grid-template-areas': '"header" "content"',
+    });
+
+    const out = fixGridTemplateSerialization(rule, lossyCssText);
+
+    expect(out).toContain('grid-template-areas: "header" "content"');
+    expect(out).not.toContain('grid-template-rows');
+    expect(out).not.toContain('grid-template-columns');
+  });
+
+  it('is a no-op when the serialized rule already contains the full areas value', () => {
+    const cssText =
+      '.p-campaign { grid-template-areas: "header" "content" "description"; }';
+    const rule = makeRule(cssText, {
+      'grid-template-areas': '"header" "content" "description"',
+    });
+
+    expect(fixGridTemplateSerialization(rule, cssText)).toBe(cssText);
+  });
+
+  it('is a no-op when grid-template-areas is unset or none', () => {
+    const cssText = '.box { color: red; }';
+    expect(fixGridTemplateSerialization(makeRule(cssText, {}), cssText)).toBe(
+      cssText,
+    );
+    expect(
+      fixGridTemplateSerialization(
+        makeRule(cssText, { 'grid-template-areas': 'none' }),
+        cssText,
+      ),
+    ).toBe(cssText);
+  });
+
+  it('does not throw when rule.style is unavailable', () => {
+    const cssText = '.box { color: red; }';
+    const brokenRule = {
+      selectorText: '.box',
+      cssText,
+      get style(): CSSStyleDeclaration {
+        throw new Error('no style');
+      },
+    } as unknown as CSSStyleRule;
+    expect(fixGridTemplateSerialization(brokenRule, cssText)).toBe(cssText);
+  });
+
+  it('preserves a multi-row grid-template-areas authored as longhands through stringifyStylesheet', () => {
+    // Round-trip guard: authoring the longhands directly should always survive
+    // serialization (this path is faithful even in real Chrome).
+    const dom = new JSDOM(
+      `<style>.p-campaign{display:grid;grid-template-areas:"header" "content" "description";grid-template-rows:auto 1fr auto;grid-template-columns:1fr;}</style>`,
+    );
+    const style = dom.window.document.querySelector('style');
+    const out = stringifyStylesheet(style!.sheet as unknown as CSSStyleSheet);
+    expect(out).toContain('"header" "content" "description"');
+  });
+});


### PR DESCRIPTION
## Root cause

The page lays out sections with CSS Grid on `.p-campaign`. Children pin to named grid areas (`grid-row-start: content/description/sidebar/header/collage/byline`). The grid container must define those areas via a multi-row `grid-template-areas`. But in the recorded snapshot the only `.p-campaign` template that survives is a single-row `grid-template: "partner-banner" / 1fr;` — the multi-row `grid-template-areas` is **absent from all captured CSS**, so children collapse onto one implicit cell and overlap.

CSS is stored as `_cssText` on inlined `<link>` nodes, produced by `stringifyStylesheet()` → `stringifyRule()` → `rule.cssText` in `packages/rrweb-snapshot/src/utils.ts`. The loss is at the CSSOM `rule.cssText` layer: real Chrome's serialization of the `grid` / `grid-template` shorthand (when `grid-template-areas` + named lines/areas are involved) does not round-trip the full template. This is **not** a `splitCssText`, `@container`/`@layer`, adopted-stylesheets, or cross-origin/inlining issue — those were all ruled out.

## What changed

New `fixGridTemplateSerialization(rule, cssText)` in `utils.ts`, called from `stringifyRule` for `CSSStyleRule`s. The CSSOM longhands (`grid-template-areas` / `-rows` / `-columns`) remain intact on `rule.style` even when `cssText` is lossy, so when the serialized rule has lost the full areas value, we re-emit those longhands read straight from the CSSOM (after the existing declarations, so they win in cascade order). 

Guarded to be a strict no-op unless `grid-template-areas` is set **and** missing from the serialized text — so the common path and faithful engines are unaffected.

## ⚠️ Test-env caveat — could not reproduce in jsdom/happy-dom (opening as draft)

Neither jsdom nor happy-dom reproduces Chrome's lossy CSSOM serialization:
- They store the `grid`/`grid-template` shorthand **verbatim** (which actually preserves the template), and
- `rule.style.getPropertyValue('grid-template-areas')` returns `""` for shorthand input.

So the original capture-side loss **cannot be reproduced in the unit-test environment**. The fix is therefore defensive and is verified by:
1. Direct unit tests against a **simulated lossy rule** (mimicking Chrome: intact longhands + collapsed `cssText`) asserting the longhands are re-emitted, plus no-op / guard cases.
2. A round-trip guard through `stringifyStylesheet` for longhand-authored multi-row areas.

A **real-Chrome capture repro is the definitive confirmation** of the end-to-end fix.

## Verification (local)

- `vitest run` (rrweb-snapshot): 132 passed, 1 skipped — green
- New `test/grid-template.test.ts`: 6 passed
- `eslint src`: 0 errors (pre-existing warnings only)
- `tsc --noEmit`: clean
- prettier: formatted

Linear: https://linear.app/amplitude/issue/SR-4667

Made with [Cursor](https://cursor.com)