### PR TITLE
chore: add environment to publish for RRWeb

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     needs: [authorize]
+    environment: npm-release
     permissions:
       id-token: write # Required for OIDC
       contents: write


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single workflow metadata change; it may require environment approval before publishes but does not alter build or publish scripts.
> 
> **Overview**
> The **Release** workflow’s `release` job now targets the GitHub **`npm-release`** environment so npm publish runs behind environment protection (approvals, environment-scoped secrets, etc.) instead of executing immediately after the authorize job alone.
> 
> No other workflow steps or publish logic change in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d4434d19664051743bde76d429360e9381e3fb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->