### PR TITLE
feat: add dom target field

### DIFF
--- a/packages/capture/src/dom-utils.ts
+++ b/packages/capture/src/dom-utils.ts
@@ -20,12 +20,17 @@ export type PageDimensions = {
  *
  * @param excludeEl - An optional element to skip during the scan (e.g. an
  *                    injected host element that should not influence measurements).
+ * @param targetDocument - The document to measure. Defaults to the global
+ *                    `document`. Pass an iframe's `contentDocument` to measure
+ *                    a page rendered inside a device frame.
  */
 export function getFullPageDimensions(
   excludeEl?: HTMLElement | null,
+  targetDocument: Document = document,
 ): PageDimensions {
-  const doc = document.documentElement;
-  const body = document.body;
+  const doc = targetDocument.documentElement;
+  const body = targetDocument.body;
+  const view = targetDocument.defaultView ?? window;
 
   let maxHeight = Math.max(
     body.scrollHeight,
@@ -42,11 +47,12 @@ export function getFullPageDimensions(
     doc.clientWidth,
   );
 
-  const els = document.body.querySelectorAll('*');
+  const els = body.querySelectorAll('*');
   const limit = Math.min(els.length, MAX_ELEMENTS_TO_CHECK);
+  const HTMLElementCtor = view.HTMLElement ?? HTMLElement;
   for (let i = 0; i < limit; i++) {
     const el = els[i];
-    if (el === excludeEl || !(el instanceof HTMLElement)) continue;
+    if (el === excludeEl || !(el instanceof HTMLElementCtor)) continue;
 
     const sh = el.scrollHeight;
     const sw = el.scrollWidth;
@@ -56,7 +62,7 @@ export function getFullPageDimensions(
     // Skip elements that aren't overflowing in either dimension
     if (sh <= ch && sw <= cw) continue;
 
-    const style = getComputedStyle(el);
+    const style = view.getComputedStyle(el);
 
     if (sh > ch && OVERFLOW_SCROLLABLE.has(style.overflowY)) {
       if (sh > maxHeight) maxHeight = sh;
@@ -78,8 +84,9 @@ export function getFullPageDimensions(
 export function getFullPageDimension(
   axis: 'height' | 'width',
   excludeEl?: HTMLElement | null,
+  targetDocument: Document = document,
 ): number {
-  const dims = getFullPageDimensions(excludeEl);
+  const dims = getFullPageDimensions(excludeEl, targetDocument);
   return axis === 'height' ? dims.pageHeight : dims.pageWidth;
 }
 
@@ -95,10 +102,17 @@ const FREEZE_ANIMATIONS_CSS = `*, *::before, *::after {
  * then injects a stylesheet that prevents them from replaying when the
  * snapshot is rendered.
  *
+ * @param targetDocument - The document whose animations to freeze. Defaults to
+ *                    the global `document`. Pass an iframe's `contentDocument`
+ *                    to freeze a page rendered inside a device frame.
  * @returns A cleanup function that removes the injected stylesheet.
  */
-export function freezeAnimations(): () => void {
-  for (const anim of document.getAnimations()) {
+export function freezeAnimations(
+  targetDocument: Document = document,
+): () => void {
+  // `getAnimations` is not implemented in every environment (e.g. jsdom).
+  const getAnimations = targetDocument.getAnimations?.bind(targetDocument);
+  for (const anim of getAnimations?.() ?? []) {
     try {
       anim.finish();
     } catch {
@@ -108,10 +122,10 @@ export function freezeAnimations(): () => void {
     }
   }
 
-  const style = document.createElement('style');
+  const style = targetDocument.createElement('style');
   style.setAttribute('data-amp-freeze', '');
   style.textContent = FREEZE_ANIMATIONS_CSS;
-  document.head.appendChild(style);
+  targetDocument.head.appendChild(style);
 
   return () => style.remove();
 }

--- a/packages/capture/src/dom-utils.ts
+++ b/packages/capture/src/dom-utils.ts
@@ -18,15 +18,15 @@ export type PageDimensions = {
  * it only queries `querySelectorAll('*')` and `getComputedStyle` once per
  * element.
  *
- * @param excludeEl - An optional element to skip during the scan (e.g. an
- *                    injected host element that should not influence measurements).
  * @param targetDocument - The document to measure. Defaults to the global
  *                    `document`. Pass an iframe's `contentDocument` to measure
  *                    a page rendered inside a device frame.
+ * @param excludeEl - An optional element to skip during the scan (e.g. an
+ *                    injected host element that should not influence measurements).
  */
 export function getFullPageDimensions(
-  excludeEl?: HTMLElement | null,
   targetDocument: Document = document,
+  excludeEl?: HTMLElement | null,
 ): PageDimensions {
   const doc = targetDocument.documentElement;
   const body = targetDocument.body;
@@ -83,10 +83,10 @@ export function getFullPageDimensions(
  */
 export function getFullPageDimension(
   axis: 'height' | 'width',
-  excludeEl?: HTMLElement | null,
   targetDocument: Document = document,
+  excludeEl?: HTMLElement | null,
 ): number {
-  const dims = getFullPageDimensions(excludeEl, targetDocument);
+  const dims = getFullPageDimensions(targetDocument, excludeEl);
   return axis === 'height' ? dims.pageHeight : dims.pageWidth;
 }
 

--- a/packages/capture/src/index.ts
+++ b/packages/capture/src/index.ts
@@ -10,6 +10,15 @@ export type CaptureOptions = {
    * dimension measurements.
    */
   excludeEl?: HTMLElement | null;
+  /**
+   * The document to capture. Defaults to the global `document`. Pass an
+   * iframe's `contentDocument` to capture a page rendered inside a device
+   * frame (e.g. a mobile/desktop viewport simulator). All reported
+   * dimensions, scroll, and inner-size metrics reflect the target frame.
+   *
+   * Must be same-origin so its DOM and stylesheets are accessible.
+   */
+  targetDocument?: Document | null;
 };
 
 export type CaptureResult = {
@@ -46,13 +55,16 @@ export type CaptureResult = {
 export function captureFullSnapshot(
   options: CaptureOptions = {},
 ): CaptureResult {
-  const { excludeEl = null } = options;
+  const { excludeEl = null, targetDocument = null } = options;
 
-  const unfreezeAnimations = freezeAnimations();
+  const doc = targetDocument ?? document;
+  const win = doc.defaultView ?? window;
+
+  const unfreezeAnimations = freezeAnimations(doc);
 
   try {
     const mirror = new Mirror();
-    const snap = snapshot(document, {
+    const snap = snapshot(doc, {
       mirror,
       inlineImages: false,
       inlineStylesheet: true,
@@ -62,7 +74,7 @@ export function captureFullSnapshot(
 
     if (snap) {
       const nextId = { value: getNextIdFromMirror(mirror) };
-      injectAllAdoptedStyles(snap, mirror, nextId);
+      injectAllAdoptedStyles(snap, mirror, nextId, doc);
     }
 
     const fullSnapshotEvent = snap
@@ -72,30 +84,30 @@ export function captureFullSnapshot(
           data: {
             node: snap,
             initialOffset: {
-              left: typeof window.scrollX === 'number' ? window.scrollX : 0,
-              top: typeof window.scrollY === 'number' ? window.scrollY : 0,
+              left: typeof win.scrollX === 'number' ? win.scrollX : 0,
+              top: typeof win.scrollY === 'number' ? win.scrollY : 0,
             },
           },
         }
       : null;
 
-    const { pageHeight, pageWidth } = getFullPageDimensions(excludeEl);
+    const { pageHeight, pageWidth } = getFullPageDimensions(excludeEl, doc);
 
     return {
       fullSnapshotEvent,
-      pageUrl: window.location.href,
-      pageTitle: document.title || null,
+      pageUrl: doc.location?.href ?? win.location.href,
+      pageTitle: doc.title || null,
       capturedAt: new Date().toISOString(),
-      scrollX: window.scrollX,
-      scrollY: window.scrollY,
-      scrollHeight: document.documentElement.scrollHeight,
-      scrollWidth: document.documentElement.scrollWidth,
-      clientHeight: document.documentElement.clientHeight,
-      clientWidth: document.documentElement.clientWidth,
+      scrollX: win.scrollX,
+      scrollY: win.scrollY,
+      scrollHeight: doc.documentElement.scrollHeight,
+      scrollWidth: doc.documentElement.scrollWidth,
+      clientHeight: doc.documentElement.clientHeight,
+      clientWidth: doc.documentElement.clientWidth,
       pageHeight,
       pageWidth,
-      innerHeight: window.innerHeight,
-      innerWidth: window.innerWidth,
+      innerHeight: win.innerHeight,
+      innerWidth: win.innerWidth,
     };
   } finally {
     unfreezeAnimations();

--- a/packages/capture/src/index.ts
+++ b/packages/capture/src/index.ts
@@ -91,7 +91,7 @@ export function captureFullSnapshot(
         }
       : null;
 
-    const { pageHeight, pageWidth } = getFullPageDimensions(excludeEl, doc);
+    const { pageHeight, pageWidth } = getFullPageDimensions(doc, excludeEl);
 
     return {
       fullSnapshotEvent,

--- a/packages/capture/src/snapshot-utils.ts
+++ b/packages/capture/src/snapshot-utils.ts
@@ -78,8 +78,9 @@ export function injectAllAdoptedStyles(
   snap: serializedNodeWithId,
   mirror: Mirror,
   nextId: { value: number },
+  targetDocument: Document = document,
 ): void {
-  const docCss = serializeAdoptedStyleSheets(document);
+  const docCss = serializeAdoptedStyleSheets(targetDocument);
 
   function walk(node: serializedNodeWithId): void {
     // Shadow DOM adopted stylesheets
@@ -162,8 +163,9 @@ export function injectAdoptedStyles(
 export function injectDocumentAdoptedStyles(
   snap: serializedNodeWithId,
   nextId: { value: number },
+  targetDocument: Document = document,
 ): void {
-  const docCss = serializeAdoptedStyleSheets(document);
+  const docCss = serializeAdoptedStyleSheets(targetDocument);
   if (!docCss || !hasChildNodes(snap)) return;
 
   const html = snap.childNodes.find(

--- a/packages/capture/test/capture.test.ts
+++ b/packages/capture/test/capture.test.ts
@@ -129,3 +129,69 @@ describe('captureFullSnapshot', () => {
     expect('childNodes' in node!).toBe(true);
   });
 });
+
+describe('captureFullSnapshot with targetDocument', () => {
+  let iframe: HTMLIFrameElement;
+
+  beforeEach(() => {
+    iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    const idoc = iframe.contentDocument!;
+    if (!idoc.getAnimations) {
+      idoc.getAnimations = () => [];
+    }
+    idoc.title = 'Iframe Page';
+    idoc.body.innerHTML = '<div id="frame-content"><p>Inside frame</p></div>';
+  });
+
+  afterEach(() => {
+    iframe.remove();
+  });
+
+  it('captures the iframe document, not the top-level document', () => {
+    // Top-level document has different content
+    document.title = 'Top Page';
+    document.body.innerHTML = '<div id="top-content">Top level</div>';
+
+    const result = captureFullSnapshot({
+      targetDocument: iframe.contentDocument,
+    });
+
+    expect(result.fullSnapshotEvent).not.toBeNull();
+    expect(result.pageTitle).toBe('Iframe Page');
+    // Reported metrics should come from the iframe's frame, not the top window
+    expect(result.innerWidth).toBe(iframe.contentWindow!.innerWidth);
+    expect(result.scrollHeight).toBe(
+      iframe.contentDocument!.documentElement.scrollHeight,
+    );
+  });
+
+  it('serializes DOM nodes from inside the iframe', () => {
+    const result = captureFullSnapshot({
+      targetDocument: iframe.contentDocument,
+    });
+    const json = JSON.stringify(result.fullSnapshotEvent!.data.node);
+
+    expect(json).toContain('Inside frame');
+  });
+
+  it('injects the freeze stylesheet into the iframe and cleans it up', () => {
+    captureFullSnapshot({ targetDocument: iframe.contentDocument });
+
+    // Freeze stylesheet should have been removed from the iframe after capture
+    expect(
+      iframe.contentDocument!.querySelector('style[data-amp-freeze]'),
+    ).toBeNull();
+    // And never leaked into the top document
+    expect(document.querySelector('style[data-amp-freeze]')).toBeNull();
+  });
+
+  it('falls back to the global document when targetDocument is null', () => {
+    document.title = 'Top Page';
+    document.body.innerHTML = '<div>top</div>';
+
+    const result = captureFullSnapshot({ targetDocument: null });
+
+    expect(result.pageTitle).toBe('Top Page');
+  });
+});

--- a/packages/capture/test/dom-utils.test.ts
+++ b/packages/capture/test/dom-utils.test.ts
@@ -82,13 +82,13 @@ describe('getFullPageDimensions', () => {
     const el = document.createElement('div');
     document.body.appendChild(el);
 
-    const dims = getFullPageDimensions(el);
+    const dims = getFullPageDimensions(document, el);
     expect(typeof dims.pageHeight).toBe('number');
     expect(typeof dims.pageWidth).toBe('number');
   });
 
   it('handles null excludeEl gracefully', () => {
-    const dims = getFullPageDimensions(null);
+    const dims = getFullPageDimensions(document, null);
     expect(typeof dims.pageHeight).toBe('number');
     expect(typeof dims.pageWidth).toBe('number');
   });
@@ -109,7 +109,7 @@ describe('getFullPageDimension', () => {
     const el = document.createElement('div');
     document.body.appendChild(el);
 
-    const height = getFullPageDimension('height', el);
+    const height = getFullPageDimension('height', document, el);
     expect(typeof height).toBe('number');
   });
 });


### PR DESCRIPTION
## Summary

- Add an optional `targetDocument` capture option so `captureFullSnapshot` can snapshot a same-origin iframe document instead of always using the top-level `document`.
- Thread the selected document/window through snapshot serialization, adopted stylesheet injection, animation freezing, page dimension measurement, and reported URL/title/scroll/viewport metrics.
- Preserve existing behavior by defaulting to the global document, treating `targetDocument: null` as the default path, and tolerating environments where `Document.getAnimations` is unavailable.

## Test coverage

- Adds coverage for capturing iframe DOM content and frame-specific metrics.
- Verifies the animation freeze stylesheet is scoped to the target iframe document and cleaned up after capture.
- Verifies `targetDocument: null` falls back to the top-level document.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes capture scoping and public helper signatures (`getFullPageDimension` argument order); wrong document choice could snapshot incorrect content, though same-origin is required and defaults are unchanged.
> 
> **Overview**
> Adds optional **`targetDocument`** to `captureFullSnapshot` so same-origin iframe documents (e.g. device-frame simulators) can be snapshotted instead of always using the top-level `document`.
> 
> The chosen document and its `defaultView` drive rrweb snapshotting, adopted stylesheet injection, animation freeze/cleanup, page dimension measurement, and all returned metadata (URL, title, scroll, viewport, and full-page size). **`targetDocument: null`** still falls back to the global document. **`freezeAnimations`** and dimension helpers now accept a document and use that frame’s `getComputedStyle` / `HTMLElement`; **`getAnimations`** is optional for jsdom.
> 
> **Breaking note for direct `dom-utils` callers:** `getFullPageDimension` / `getFullPageDimensions` now take `targetDocument` before `excludeEl` (e.g. `getFullPageDimension('height', document, el)`).
> 
> Tests cover iframe DOM/metrics, scoped freeze stylesheet cleanup, and the null fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c765bebf42b3b70103c3d6a98ae8034fc1ad110. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->