### PR TITLE
chore: fix playwright download url

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -30,7 +30,6 @@ jobs:
         run: pnpm install --frozen-lockfile
         env:
           PUPPETEER_DOWNLOAD_BASE_URL: 'https://storage.googleapis.com/chrome-for-testing-public'
-          PLAYWRIGHT_DOWNLOAD_HOST: https://cdn.playwright.dev/dbazure/download/playwright
 
       - name: Build Project
         run: NODE_OPTIONS='--max-old-space-size=4096' pnpm build:all

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -30,6 +30,7 @@ jobs:
         run: pnpm install --frozen-lockfile
         env:
           PUPPETEER_DOWNLOAD_BASE_URL: 'https://storage.googleapis.com/chrome-for-testing-public'
+          PLAYWRIGHT_DOWNLOAD_HOST: https://cdn.playwright.dev/dbazure/download/playwright
 
       - name: Build Project
         run: NODE_OPTIONS='--max-old-space-size=4096' pnpm build:all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,10 @@ jobs:
         run: pnpm install --frozen-lockfile
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
+          # Playwright 1.44.1 defaults to the retired playwright.azureedge.net
+          # CDN, which hangs/stalls on download. Point at the current Microsoft
+          # CDN, which serves the same /builds/<browser>/<rev>/... layout.
+          PLAYWRIGHT_DOWNLOAD_HOST: https://cdn.playwright.dev/dbazure/download/playwright
 
       - name: Build packages
         run: pnpm build:all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,11 +93,10 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
         env:
-          PUPPETEER_SKIP_DOWNLOAD: true
-          # This job only builds and publishes — it never launches a browser.
-          # rrvideo's `install` lifecycle runs `playwright install`, whose
-          # download hangs post-transfer on Playwright 1.44.1. Skip it here.
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+          # Browser binaries must be provisioned here: the "Run tests" step
+          # below gates publish on the full suite, which launches Puppeteer
+          # (rrweb et al.) and Playwright Chromium (rrvideo). Mirrors ci-cd.yml.
+          PUPPETEER_DOWNLOAD_BASE_URL: 'https://storage.googleapis.com/chrome-for-testing-public'
 
       - name: Build packages
         run: pnpm build:all
@@ -107,8 +106,10 @@ jobs:
       - name: Run tests
         # Gate publish on tests passing. Skipped for dry-run since dry-run
         # is just a version-bump preview, not an actual release.
+        # Puppeteer-based tests need a display + headless mode, so run under
+        # xvfb with PUPPETEER_HEADLESS, matching ci-cd.yml.
         if: ${{ github.event.inputs.releaseType != 'dry-run' }}
-        run: pnpm test
+        run: PUPPETEER_HEADLESS=true xvfb-run --server-args="-screen 0 1920x1080x24" pnpm test
 
       - name: Reset working tree
         # Build prepublish hooks mutate tracked files (tsconfig project references).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,10 +94,10 @@ jobs:
         run: pnpm install --frozen-lockfile
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
-          # Playwright 1.44.1 defaults to the retired playwright.azureedge.net
-          # CDN, which hangs/stalls on download. Point at the current Microsoft
-          # CDN, which serves the same /builds/<browser>/<rev>/... layout.
-          PLAYWRIGHT_DOWNLOAD_HOST: https://cdn.playwright.dev/dbazure/download/playwright
+          # This job only builds and publishes — it never launches a browser.
+          # rrvideo's `install` lifecycle runs `playwright install`, whose
+          # download hangs post-transfer on Playwright 1.44.1. Skip it here.
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
       - name: Build packages
         run: pnpm build:all

--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -26,6 +26,7 @@ jobs:
         run: pnpm install --frozen-lockfile
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
+          PLAYWRIGHT_DOWNLOAD_HOST: https://cdn.playwright.dev/dbazure/download/playwright
       - name: Build Packages
         run: NODE_OPTIONS='--max-old-space-size=4096' pnpm build:all
       - name: Eslint Check
@@ -60,6 +61,7 @@ jobs:
         run: pnpm install --frozen-lockfile
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
+          PLAYWRIGHT_DOWNLOAD_HOST: https://cdn.playwright.dev/dbazure/download/playwright
       - name: Prettier Check
         run: pnpm exec prettier --check '**/*.{ts,md}'
 
@@ -85,6 +87,7 @@ jobs:
         run: pnpm install --frozen-lockfile
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
+          PLAYWRIGHT_DOWNLOAD_HOST: https://cdn.playwright.dev/dbazure/download/playwright
       - name: Prettify Code
         run: pnpm exec prettier --write '**/*.{ts,md}'
       - name: Commit Changes

--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -26,7 +26,9 @@ jobs:
         run: pnpm install --frozen-lockfile
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
-          PLAYWRIGHT_DOWNLOAD_HOST: https://cdn.playwright.dev/dbazure/download/playwright
+          # Lint/format jobs never launch a browser; skip rrvideo's
+          # `playwright install` download (hangs post-transfer on 1.44.1).
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
       - name: Build Packages
         run: NODE_OPTIONS='--max-old-space-size=4096' pnpm build:all
       - name: Eslint Check
@@ -61,7 +63,9 @@ jobs:
         run: pnpm install --frozen-lockfile
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
-          PLAYWRIGHT_DOWNLOAD_HOST: https://cdn.playwright.dev/dbazure/download/playwright
+          # Lint/format jobs never launch a browser; skip rrvideo's
+          # `playwright install` download (hangs post-transfer on 1.44.1).
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
       - name: Prettier Check
         run: pnpm exec prettier --check '**/*.{ts,md}'
 
@@ -87,7 +91,9 @@ jobs:
         run: pnpm install --frozen-lockfile
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
-          PLAYWRIGHT_DOWNLOAD_HOST: https://cdn.playwright.dev/dbazure/download/playwright
+          # Lint/format jobs never launch a browser; skip rrvideo's
+          # `playwright install` download (hangs post-transfer on 1.44.1).
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
       - name: Prettify Code
         run: pnpm exec prettier --write '**/*.{ts,md}'
       - name: Commit Changes

--- a/packages/rrvideo/package.json
+++ b/packages/rrvideo/package.json
@@ -12,7 +12,7 @@
   ],
   "types": "build/index.d.ts",
   "scripts": {
-    "install": "playwright install",
+    "install": "playwright install chromium",
     "build": "tsc",
     "test": "jest",
     "check-types": "tsc -noEmit",

--- a/packages/rrvideo/package.json
+++ b/packages/rrvideo/package.json
@@ -39,6 +39,6 @@
     "@open-tech-world/cli-progress-bar": "^2.0.2",
     "fs-extra": "^11.1.1",
     "minimist": "^1.2.5",
-    "playwright": "^1.32.1"
+    "playwright": "1.60.0"
   }
 }

--- a/packages/rrvideo/package.json
+++ b/packages/rrvideo/package.json
@@ -12,7 +12,7 @@
   ],
   "types": "build/index.d.ts",
   "scripts": {
-    "install": "playwright install chromium",
+    "install": "playwright install chromium", 
     "build": "tsc",
     "test": "jest",
     "check-types": "tsc -noEmit",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -453,8 +453,8 @@ importers:
         specifier: ^1.2.5
         version: 1.2.8
       playwright:
-        specifier: ^1.32.1
-        version: 1.44.1
+        specifier: 1.60.0
+        version: 1.60.0
     devDependencies:
       '@amplitude/rrweb':
         specifier: workspace:^
@@ -5912,14 +5912,14 @@ packages:
   pkg-types@1.1.1:
     resolution: {integrity: sha512-ko14TjmDuQJ14zsotODv7dBlwxKhUKQEhuhmbqo1uCi9BB0Z2alo/wAXg6q1dTR5TyuqYyWhjtfe/Tsh+X28jQ==}
 
-  playwright-core@1.44.1:
-    resolution: {integrity: sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==}
-    engines: {node: '>=16'}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.44.1:
-    resolution: {integrity: sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==}
-    engines: {node: '>=16'}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
     hasBin: true
 
   pngjs@3.4.0:
@@ -13971,11 +13971,11 @@ snapshots:
       mlly: 1.7.1
       pathe: 1.1.2
 
-  playwright-core@1.44.1: {}
+  playwright-core@1.60.0: {}
 
-  playwright@1.44.1:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.44.1
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
**Fix release/CI hang during dependency install (Playwright CDN retired)**

Run - https://github.com/amplitude/rrweb/actions/runs/28269183768

`packages/rrvideo` has an `install` script (`playwright install`), so `pnpm install --frozen-lockfile` triggers a Playwright browser download on every release and style-check run. Playwright 1.44.1 defaults to `playwright.azureedge.net`, which Microsoft has retired — it stalls/hangs near completion (the install would freeze right after Chromium hit 100%).

**Fix:** set `PLAYWRIGHT_DOWNLOAD_HOST=https://cdn.playwright.dev/dbazure/download/playwright` on the install steps in `release.yml` and `style-check.yml` (×3). This points downloads at the current Microsoft CDN, which serves the same `/builds/<browser>/<rev>/...` layout 1.44.1 expects (the subpath regression only affects 1.58.0+).

**Verified:** `curl -IL` on the v1117 Chromium build returns `307 → 200` from `cdn.playwright.dev` → `playwright.download.prss.microsoft.com`. Can also confirm via a `dry-run` of the Release workflow, which exercises the install step without publishing.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow and dev-dependency changes only; no runtime library behavior changes beyond Playwright version bump in rrvideo.
> 
> **Overview**
> Fixes **CI/release installs hanging** when `rrvideo`’s postinstall runs Playwright, and makes **release test runs** actually provision and run browser-based suites.
> 
> **`@amplitude/rrvideo`:** Pins **Playwright 1.60.0** (lockfile updated) and narrows the install script from `playwright install` to **`playwright install chromium`** so only Chromium is fetched.
> 
> **`style-check.yml`:** All three `pnpm install` steps set **`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`** so lint/format jobs don’t download browsers (avoids the 1.44.1 post-transfer hang).
> 
> **`release.yml`:** Drops **`PUPPETEER_SKIP_DOWNLOAD`** on install and sets **`PUPPETEER_DOWNLOAD_BASE_URL`** to Chrome for Testing (same as `ci-cd.yml`) so Puppeteer binaries are available before publish-gating tests. **`Run tests`** now runs under **`xvfb-run`** with **`PUPPETEER_HEADLESS=true`**, matching main CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d569d9c51868a4079f2383b0ec16a56254b78c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->