### PR TITLE
fix(replay): reset styleMirror per FullSnapshot to match recorder scoping

### DIFF
--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1064,6 +1064,18 @@ export class Replayer {
     }
 
     this.mirror.reset();
+
+    // record/stylesheet-manager.ts's StylesheetManager.reset() resets its
+    // styleMirror right before every snapshot() call (see record/index.ts),
+    // so a given styleId is only unique within one FullSnapshot generation -
+    // the same small integer in the next generation refers to an unrelated
+    // stylesheet. Mirror that here: without this reset,
+    // applySnapshotAdoptedStyleSheets would resolve a recycled styleId to the
+    // previous generation's cached CSSStyleSheet, corrupting that sheet and
+    // producing incorrect (often oversized) styles for shadow-DOM
+    // adoptedStyleSheets.
+    this.styleMirror.reset();
+
     rebuild(event.data.node, {
       doc: this.iframe.contentDocument,
       afterAppend,


### PR DESCRIPTION
## Problem
The replayer's `styleMirror` (a `styleId → CSSStyleSheet` cache) is only reset on seek/checkout/destroy — never at the start of a FullSnapshot rebuild. But the recorder's `StylesheetManager.reset()` (`record/stylesheet-manager.ts`) resets its own `styleMirror` right before every `snapshot()` call, so `styleId`s are only unique within a single FullSnapshot generation, by design.

This means during forward playback across multiple FullSnapshots, a recycled `styleId` in generation 2 can collide with generation 1's id. `applySnapshotAdoptedStyleSheets` sees `existing` for that id and reuses (and appends to) generation 1's cached `CSSStyleSheet` instead of building generation 2's — corrupting the shared sheet and producing wrong/incorrect styles for shadow-DOM `adoptedStyleSheets`.

## Fix
Reset `styleMirror` at the start of `rebuildFullSnapshot`, alongside the existing `this.mirror.reset()`, so the replayer's styleId scoping matches the recorder's.

## Testing
Verified locally against a fork build linked into a consuming app: adopted stylesheets render correctly across multiple FullSnapshot generations, both on initial playback and after seeking.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted replay fix aligned with existing recorder semantics; duplicate resets on paths that already clear `styleMirror` before rebuild are harmless.
> 
> **Overview**
> Resets the replayer’s `styleMirror` cache at the start of **`rebuildFullSnapshot`**, next to the existing `mirror.reset()`, so `styleId` → `CSSStyleSheet` mappings are scoped to a single FullSnapshot generation like the recorder.
> 
> Without this, forward playback across multiple FullSnapshots could reuse a recycled `styleId` from an earlier generation in **`applySnapshotAdoptedStyleSheets`**, corrupting shared sheets and breaking shadow-DOM **`adoptedStyleSheets`** styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eff574bc8eb16612ccd6eac4a8903539b7b0b0c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->